### PR TITLE
Changes to increase notebook upload limit

### DIFF
--- a/experiments/hadoop-yarn/ansible/27-install-zeppelin.yml
+++ b/experiments/hadoop-yarn/ansible/27-install-zeppelin.yml
@@ -157,11 +157,17 @@
                 </property>
  
                 <property>
+                    <name>zeppelin.websocket.max.text.message.size</name>
+                    <value>10240000</value>
+                    <description></description>
+                </property>
+                
+                <property>
                     <name>zeppelin.interpreter.output.limit</name>
-                    <value>102400</value>
+                    <value>10240000</value>
                     <description>Output message from interpreter exceeding the limit will be truncated</description>
                 </property>
-
+                
                 <property>
                     <name>zeppelin.ssl</name>
                     <value>false</value>


### PR DESCRIPTION
Increased size limit for uploaded notebooks to 10Mb in Zeppelin configuration. Fix was tested in a new deploy with a Notebook of size: 1.1Mb.
![Screenshot from 2021-02-09 19-22-15](https://user-images.githubusercontent.com/10408723/107402360-87f9b280-6b0c-11eb-9f48-fc98fed2337b.png)
