### PR TITLE
20210211 zrq move vars

### DIFF
--- a/experiments/hadoop-yarn/ansible/03-create-masters.yml
+++ b/experiments/hadoop-yarn/ansible/03-create-masters.yml
@@ -35,7 +35,7 @@
       register:
         mastersec
 
-    - name: "Add a rule to allow SSH from our gateway"
+    - name: "Add a rule to allow SSH from zeppelin"
       os_security_group_rule:
         cloud: "{{ cloudname }}"
         state: present
@@ -44,7 +44,7 @@
         protocol:  'tcp'
         port_range_min: 22
         port_range_max: 22
-        remote_group: "{{ security['gateway'] }}"
+        remote_group: "{{ security['zeppelin'] }}"
 
     - name: "Create our masters"
       os_server:

--- a/experiments/hadoop-yarn/ansible/04-create-workers.yml
+++ b/experiments/hadoop-yarn/ansible/04-create-workers.yml
@@ -35,7 +35,7 @@
       register:
         secgroup
 
-    - name: "Add a rule to allow ssh from the gateway"
+    - name: "Add a rule to allow ssh from zeppelin"
       os_security_group_rule:
         cloud: "{{ cloudname }}"
         state: present
@@ -44,7 +44,7 @@
         protocol:  'tcp'
         port_range_min: 22
         port_range_max: 22
-        remote_group: "{{ security['gateway'] }}"
+        remote_group: "{{ security['zeppelin'] }}"
 
     - name: "Create our workers"
       os_server:

--- a/experiments/hadoop-yarn/ansible/05-config-ssh.yml
+++ b/experiments/hadoop-yarn/ansible/05-config-ssh.yml
@@ -35,12 +35,12 @@
         mode: 'u=rwx,g=rx,o=rx'
         state: directory
 
-    - name: "Discover our gateway nodes"
+    - name: "Discover our zeppelin node"
       os_server_info:
         cloud:  "{{ cloudname }}"
-        server: "{{ deployname }}-gateway"
+        server: "{{ deployname }}-zeppelin"
       register:
-        gatewaynodes
+        zeppelinnodes
 
     - name: "Generate Ansible SSH config"
       template:

--- a/experiments/hadoop-yarn/ansible/06-config-dns.yml
+++ b/experiments/hadoop-yarn/ansible/06-config-dns.yml
@@ -26,12 +26,12 @@
     - /tmp/ansible-vars.yml
   tasks:
 
-    - name: "Discover our gateway nodes"
+    - name: "Discover our Zeppelin node"
       os_server_info:
         cloud:  "{{ cloudname }}"
-        server: "{{ deployname }}-gateway*"
+        server: "{{ deployname }}-zeppelin"
       register:
-        gatewaynodes
+        zeppelinnode
 
     - name: "Discover our master nodes"
       os_server_info:
@@ -47,34 +47,16 @@
       register:
         workernodes
 
-    - name: "Discover our Zeppelin nodes"
-      os_server_info:
-        cloud:  "{{ cloudname }}"
-        server: "{{ deployname }}-zeppelin"
-      register:
-        zeppelinnode
-
     - name: "Generate our DNS hosts file"
       template:
         src:  'templates/dns-hosts.j2'
         dest: "/tmp/aglais-dns-hosts"
 
-- hosts: gateway
-  gather_facts: false
-  tasks:
-    - name: "Deploy [/etc/hosts] to our gateway"
-      become: true
-      copy:
-        src:  /tmp/aglais-dns-hosts
-        dest: /etc/hosts
-        owner: root
-        group: root
-        mode:  u=rw,g=r,o=r
 
 - hosts: zeppelin
   gather_facts: false
   tasks:
-    - name: "Deploy [/etc/hosts] to our Zeppelin"
+    - name: "Deploy [/etc/hosts] to our Zeppelin node"
       become: true
       copy:
         src:  /tmp/aglais-dns-hosts

--- a/experiments/hadoop-yarn/ansible/07-host-keys.yml
+++ b/experiments/hadoop-yarn/ansible/07-host-keys.yml
@@ -22,7 +22,7 @@
 # https://everythingshouldbevirtual.com/automation/ansible-ssh-known-host-keys/
 #
 
-- hosts: gateway
+- hosts: zeppelin
   gather_facts: false
   tasks:
 
@@ -50,7 +50,7 @@
         dest: "/tmp/aglais-ssh-hosts"
 
 
-- hosts: gateway:masters:workers:zeppelin
+- hosts: masters:workers:zeppelin
   gather_facts: false
   tasks:
     - name: "Deploy the known hosts file to [/etc/ssh/ssh_known_hosts]"

--- a/experiments/hadoop-yarn/ansible/08-ping-test.yml
+++ b/experiments/hadoop-yarn/ansible/08-ping-test.yml
@@ -22,7 +22,7 @@
 
 ---
 - name: "Ping tests"
-  hosts: gateway:masters:workers:zeppelin
+  hosts: zeppelin:masters:workers
   gather_facts: false
   tasks:
 

--- a/experiments/hadoop-yarn/ansible/11-install-hadoop.yml
+++ b/experiments/hadoop-yarn/ansible/11-install-hadoop.yml
@@ -29,13 +29,6 @@
 - name: "Install Hadoop"
   hosts: masters:workers:zeppelin
   gather_facts: false
-  vars:
-    hdname: "hadoop-3.1.3"
-    hdbase: "/opt"
-    hdhome: "/opt/hadoop"
-    hddata: "/var/local/hadoop"
-    hdhost: "{{groups['masters'][0]}}"
-    hduser: "{{hostvars[inventory_hostname].login}}"
 
   tasks:
 

--- a/experiments/hadoop-yarn/ansible/12-config-hadoop-core.yml
+++ b/experiments/hadoop-yarn/ansible/12-config-hadoop-core.yml
@@ -23,13 +23,6 @@
 - name: "Configure Hadoop [core-site.xml]"
   hosts: masters:workers:zeppelin
   gather_facts: false
-  vars:
-    hdname: "hadoop-3.1.3"
-    hdbase: "/opt"
-    hdhome: "/opt/hadoop"
-    hddata: "/var/local/hadoop"
-    hdhost: "{{groups['masters'][0]}}"
-    hduser: "{{hostvars[inventory_hostname].login}}"
 
   tasks:
 

--- a/experiments/hadoop-yarn/ansible/13-config-hdfs-namenode.yml
+++ b/experiments/hadoop-yarn/ansible/13-config-hdfs-namenode.yml
@@ -24,12 +24,6 @@
   hosts: master01:zeppelin
   gather_facts: false
   vars:
-    hdname: "hadoop-3.1.3"
-    hdbase: "/opt"
-    hdhome: "/opt/hadoop"
-    hddata: "/var/local/hadoop"
-    hdhost: "{{groups['masters'][0]}}"
-    hduser: "{{hostvars[inventory_hostname].login}}"
 
   tasks:
 

--- a/experiments/hadoop-yarn/ansible/14-config-hdfs-workers.yml
+++ b/experiments/hadoop-yarn/ansible/14-config-hdfs-workers.yml
@@ -23,13 +23,6 @@
 - name: "Configure Hadoop workers"
   hosts: workers:zeppelin
   gather_facts: false
-  vars:
-    hdname: "hadoop-3.1.3"
-    hdbase: "/opt"
-    hdhome: "/opt/hadoop"
-    hddata: "/var/local/hadoop"
-    hdhost: "{{groups['masters'][0]}}"
-    hduser: "{{hostvars[inventory_hostname].login}}"
 
   tasks:
 

--- a/experiments/hadoop-yarn/ansible/16-config-yarn-masters.yml
+++ b/experiments/hadoop-yarn/ansible/16-config-yarn-masters.yml
@@ -23,13 +23,6 @@
 - name: "Configure YARN masters"
   hosts: master01:zeppelin
   gather_facts: false
-  vars:
-    hdname: "hadoop-3.1.3"
-    hdbase: "/opt"
-    hdhome: "/opt/hadoop"
-    hddata: "/var/local/hadoop"
-    hdhost: "master01"
-    hduser: "{{hostvars[inventory_hostname].login}}"
 
   tasks:
 

--- a/experiments/hadoop-yarn/ansible/17-config-yarn-workers.yml
+++ b/experiments/hadoop-yarn/ansible/17-config-yarn-workers.yml
@@ -23,13 +23,6 @@
 - name: "Configure YARN workers"
   hosts: workers:zeppelin
   gather_facts: false
-  vars:
-    hdname: "hadoop-3.1.3"
-    hdbase: "/opt"
-    hdhome: "/opt/hadoop"
-    hddata: "/var/local/hadoop"
-    hdhost: "{{groups['masters'][0]}}"
-    hduser: "{{hostvars[inventory_hostname].login}}"
 
   tasks:
 

--- a/experiments/hadoop-yarn/ansible/20-install-spark.yml
+++ b/experiments/hadoop-yarn/ansible/20-install-spark.yml
@@ -24,14 +24,6 @@
 - name: "Install Spark"
   hosts: master01:zeppelin
   gather_facts: false
-  vars:
-    spname: "spark-2.4.7"
-    spfull: "spark-2.4.7-bin-hadoop2.7"
-    spbase: "/opt"
-    sphome: "/opt/spark"
-    spdata: "/var/local/spark"
-    sphost: "{{groups['masters'][0]}}"
-    spuser: "{{hostvars[inventory_hostname].login}}"
 
   tasks:
 

--- a/experiments/hadoop-yarn/ansible/22-config-spark-master.yml
+++ b/experiments/hadoop-yarn/ansible/22-config-spark-master.yml
@@ -23,15 +23,6 @@
 - name: "Configure YARN masters"
   hosts: master01:zeppelin
   gather_facts: false
-  vars:
-    hdbase: "/opt"
-    hdhome: "/opt/hadoop"
-    hdhost: "{{groups['masters'][0]}}"
-    spbase: "/opt"
-    sphome: "/opt/spark"
-    spdata: "/var/local/spark"
-    sphost: "master01"
-    spuser: "{{hostvars[inventory_hostname].login}}"
 
   tasks:
 

--- a/experiments/hadoop-yarn/ansible/24-install-pyspark.yml
+++ b/experiments/hadoop-yarn/ansible/24-install-pyspark.yml
@@ -24,12 +24,6 @@
 - name: "Install PySpark"
   hosts: master01:zeppelin
   gather_facts: false
-  vars:
-    spbase: "/opt"
-    sphome: "/opt/spark"
-    spdata: "/var/local/spark"
-    sphost: "{{groups['masters'][0]}}"
-    spuser: "{{hostvars[inventory_hostname].login}}"
 
   tasks:
 

--- a/experiments/hadoop-yarn/ansible/25-create-zeppelin.yml
+++ b/experiments/hadoop-yarn/ansible/25-create-zeppelin.yml
@@ -35,16 +35,29 @@
       register:
         zeppelinsec
 
-    - name: "Add a rule to allow ssh from the gateway"
+    - name: "Add a security rule for IPv4 SSH"
       os_security_group_rule:
         cloud: "{{ cloudname }}"
         state: present
         security_group: "{{ zeppelinsec.id }}"
         direction: 'ingress'
         protocol:  'tcp'
+        ethertype: 'IPv4'
         port_range_min: 22
         port_range_max: 22
         remote_ip_prefix: '0.0.0.0/0'
+
+    - name: "Add a security rule for IPv6 SSH"
+      os_security_group_rule:
+        cloud: "{{ cloudname }}"
+        state: present
+        security_group: "{{ zeppelinsec.id }}"
+        direction: 'ingress'
+        protocol:  'tcp'
+        ethertype: 'IPv6'
+        port_range_min: 22
+        port_range_max: 22
+        remote_ip_prefix: '::/0'
 
     - name: "Add a security rule for IPv4 Port 8080"
       os_security_group_rule:

--- a/experiments/hadoop-yarn/ansible/27-install-zeppelin.yml
+++ b/experiments/hadoop-yarn/ansible/27-install-zeppelin.yml
@@ -24,13 +24,6 @@
   hosts: zeppelin
   gather_facts: yes
   vars:
-    zepname: "zeppelin-0.8.2"
-    sphome: "/opt/spark"
-    hdhome: "/opt/hadoop"
-    zepbase: "/home/fedora"
-    zephome: "/home/fedora/zeppelin-0.8.2-bin-all"
-    zephost: "zeppelin"
-    zepuser: "{{hostvars[inventory_hostname].login}}"
     zeppelinconfig: |
             <?xml version="1.0"?>
             <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>

--- a/experiments/hadoop-yarn/ansible/51-cephfs-mount.yml
+++ b/experiments/hadoop-yarn/ansible/51-cephfs-mount.yml
@@ -38,7 +38,7 @@
 
 ---
 - name: "Install and mount a CephFS share"
-  hosts: gateway:masters:workers:zeppelin
+  hosts: zeppelin:masters:workers
   gather_facts: false
   vars_files:
     - /tmp/ansible-vars.yml

--- a/experiments/hadoop-yarn/ansible/combined-01.yml
+++ b/experiments/hadoop-yarn/ansible/combined-01.yml
@@ -22,7 +22,6 @@
 
 ---
 - import_playbook: 01-create-network.yml
-- import_playbook: 02-create-gateway.yml
 - import_playbook: 03-create-masters.yml
 - import_playbook: 04-create-workers.yml
 - import_playbook: 25-create-zeppelin.yml

--- a/experiments/hadoop-yarn/ansible/create-all.yml
+++ b/experiments/hadoop-yarn/ansible/create-all.yml
@@ -22,10 +22,9 @@
 ---
 - import_playbook: 01-create-keypair.yml
 - import_playbook: 01-create-network.yml
-- import_playbook: 02-create-gateway.yml
+- import_playbook: 25-create-zeppelin.yml
 - import_playbook: 03-create-masters.yml
 - import_playbook: 04-create-workers.yml
-- import_playbook: 25-create-zeppelin.yml
 
 - import_playbook: 05-config-ssh.yml
 - import_playbook: 06-config-dns.yml

--- a/experiments/hadoop-yarn/ansible/hosts.yml
+++ b/experiments/hadoop-yarn/ansible/hosts.yml
@@ -48,6 +48,56 @@ all:
         # https://docs.ansible.com/ansible/latest/user_guide/intro_getting_started.html#host-key-checking
         ansible_host_key_checking: false
 
+    # Hadoop vars
+
+        hdname: "hadoop-3.1.3"
+        hdbase: "/opt"
+        hdhome: "/opt/hadoop"
+
+        hdconf: "{{hdhome}}/etc/hadoop"
+        hdhost: "master01"
+        hduser: "fedora"
+
+        hddatalink: "/var/hadoop/data"
+        hddatadest: "/mnt/cinder/vdc/hadoop/data"
+
+        hdlogslink: "/var/hadoop/logs"
+        hdlogsdest: "/mnt/cinder/vdc/hadoop/logs"
+
+    # HDFS vars
+
+        hdfsconf: "/var/hdfs/conf"
+
+        hdfsmetalink: "/var/hdfs/meta"
+        hdfsmetadest: "/mnt/cinder/vdc/hdfs/meta"
+
+        hdfslogslink: "/var/hdfs/logs"
+        hdfslogsdest: "/mnt/cinder/vdc/hdfs/logs"
+
+        hdfsdatalink: "/var/hdfs/data"
+        hdfsdatadest: "/mnt/cinder/vdc/hdfs/data"
+
+  # Spark vars
+        spname: "spark-2.4.7"
+        spfull: "spark-2.4.7-bin-hadoop2.7"
+        spbase: "/opt"
+        sphome: "/opt/spark"
+        sphost: "master01"
+        spuser: "fedora"
+
+        sptemplink: "/var/spark/temp"
+        sptempdest: "/mnt/local/vdb/spark/temp"
+
+    # Zeppelin vars
+        zepname: "zeppelin-0.8.2"
+        zepbase: "/home/fedora"
+        zephome: "/home/fedora/zeppelin-0.8.2-bin-all"
+        zephost: "zeppelin"
+        zepuser: "fedora"
+
+        #zepdatalink: '/var/zeppelin/data'
+        #zepdatadest: "/mnt/cinder/vdc/zeppelin/data"
+
     hosts:
 
         zeppelin:

--- a/experiments/hadoop-yarn/ansible/hosts.yml
+++ b/experiments/hadoop-yarn/ansible/hosts.yml
@@ -49,10 +49,6 @@ all:
         ansible_host_key_checking: false
 
     hosts:
-        gateway:
-            login:  'fedora'
-            image:  'Fedora-30-1.2'
-            flavor: 'general.v1.tiny'
 
         zeppelin:
             login:  'fedora'

--- a/experiments/hadoop-yarn/ansible/templates/dns-hosts.j2
+++ b/experiments/hadoop-yarn/ansible/templates/dns-hosts.j2
@@ -26,8 +26,8 @@
 127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
 ::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
 
-# Gateway nodes.
-{% for node in gatewaynodes.openstack_servers %}
+# Zeppelin nodes.
+{% for node in zeppelinnode.openstack_servers %}
 {{ "%-15s" | format(node.private_v4,) }}  {{ node.metadata.hostname }}
 {% endfor %}
 
@@ -41,7 +41,3 @@
 {{ "%-15s" | format(node.private_v4,) }}  {{ node.metadata.hostname }}
 {% endfor %}
 
-# Zeppelin nodes.
-{% for node in zeppelinnode.openstack_servers %}
-{{ "%-15s" | format(node.private_v4,) }}  {{ node.metadata.hostname }}
-{% endfor %}

--- a/experiments/hadoop-yarn/ansible/templates/hadoop-workers.j2
+++ b/experiments/hadoop-yarn/ansible/templates/hadoop-workers.j2
@@ -1,3 +1,24 @@
+{#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2020, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#}
+
 {% for worker in groups['workers'] %}
 {{ worker }}
 {% endfor %}

--- a/experiments/hadoop-yarn/ansible/templates/ssh-ansible.j2
+++ b/experiments/hadoop-yarn/ansible/templates/ssh-ansible.j2
@@ -28,9 +28,9 @@ ServerAliveInterval 60
 ServerAliveCountMax 5
 
 # Primary gateway node.
-Host gateway
-    User {{ hostvars['gateway'].login }}
-    HostName {{ gatewaynodes.openstack_servers[0].accessIPv4 }}
+Host zeppelin
+    User {{ hostvars['zeppelin'].login }}
+    HostName {{ zeppelinnodes.openstack_servers[0].accessIPv4 }}
     ControlPath ~/.ssh/%r@%h:%p
     ControlMaster auto
     ControlPersist 5m
@@ -39,7 +39,7 @@ Host gateway
 {% for hostname in groups['masters'] %}
 Host {{ hostname }}
     User {{ hostvars[hostname]['login'] }}
-    ProxyCommand ssh -W %h:%p -l {{ hostvars['gateway'].login }} -F {{ lookup('env','HOME') }}/.ssh/ansible-config gateway
+    ProxyCommand ssh -W %h:%p -l {{ hostvars['zeppelin'].login }} -F {{ lookup('env','HOME') }}/.ssh/ansible-config zeppelin
     ControlPath ~/.ssh/%r@%h:%p
     ControlMaster auto
     ControlPersist 5m
@@ -49,19 +49,10 @@ Host {{ hostname }}
 {% for hostname in groups['workers'] %}
 Host {{ hostname }}
     User {{ hostvars[hostname]['login'] }}
-    ProxyCommand ssh -W %h:%p -l {{ hostvars['gateway'].login }} -F {{ lookup('env','HOME') }}/.ssh/ansible-config gateway
+    ProxyCommand ssh -W %h:%p -l {{ hostvars['zeppelin'].login }} -F {{ lookup('env','HOME') }}/.ssh/ansible-config zeppelin
     ControlPath ~/.ssh/%r@%h:%p
     ControlMaster auto
     ControlPersist 5m
 
 {% endfor %}
-
-
-# Zeppelin node
-Host zeppelin
-    User {{ hostvars['zeppelin']['login'] }}
-    ProxyCommand ssh -W %h:%p -l {{ hostvars['zeppelin'].login }} -F {{ lookup('env','HOME') }}/.ssh/ansible-config gateway
-    ControlPath ~/.ssh/%r@%h:%p
-    ControlMaster auto
-    ControlPersist 5m
 

--- a/experiments/openstack/bin/delete-all.sh
+++ b/experiments/openstack/bin/delete-all.sh
@@ -354,7 +354,7 @@
             --os-cloud "${cloudname:?}" \
             keypair list \
                 --format json \
-        | jq -r '.[] | select(.Name | startswith("aglais")) | .Name'
+        | jq -r '.[] | select(.Name | startswith("'${cloudname:?}'")) | .Name'
         )
     do
         echo "- Deleting key [${keyname:?}]"

--- a/notes/zrq/20210206-01-git-cherry-pick.txt
+++ b/notes/zrq/20210206-01-git-cherry-pick.txt
@@ -788,6 +788,38 @@
 
         git add 'notes/zrq/20210206-01-git-cherry-pick.txt'
 
+        git commit -m "Added notes on git cherry picking"
+
+        git push
+
+    popd
 
 
+# -----------------------------------------------------
+# Create a new working branch ....
+#[user@desktop]
+
+    prevbranch=${nextbranch:?}
+    nextbranch=$(date '+%Y%m%d')-zrq-working
+
+    source "${HOME}/aglais.env"
+    pushd  "${AGLAIS_CODE}"
+
+        git checkout -b "${nextbranch:?}"
+
+    >   Switched to a new branch '20210206-zrq-working'
+
+
+        git push --set-upstream 'origin' "${nextbranch:?}"
+
+    >   Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
+    >   remote:
+    >   remote: Create a pull request for '20210206-zrq-working' on GitHub by visiting:
+    >   remote:      https://github.com/Zarquan/aglais/pull/new/20210206-zrq-working
+    >   remote:
+    >   To github.com:Zarquan/aglais.git
+    >    * [new branch]      20210206-zrq-working -> 20210206-zrq-working
+    >   Branch '20210206-zrq-working' set up to track remote branch '20210206-zrq-working' from 'origin'.
+
+    popd
 


### PR DESCRIPTION
Moved the Hadoop, Spark and Zeppelin `vars` into `hosts.yml`.
Saves repeating them in several different places.