### PR TITLE
Notes on SSH tunnels and SOCKS proxies

### DIFF
--- a/notes/zrq/20210806-01-metrics-grafana.txt
+++ b/notes/zrq/20210806-01-metrics-grafana.txt
@@ -1,0 +1,353 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2021, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+#zrq-notes-time
+#zrq-notes-indent
+#zrq-notes-crypto
+#zrq-notes-ansible
+#zrq-notes-osformat
+#zrq-notes-zeppelin
+#
+
+    #
+    # Exploring alternatives for accessing the Spark and Grafana metrics.
+    #
+
+    #
+    # Use SSH to tunnel the connections.
+    # https://linuxize.com/post/how-to-setup-ssh-tunneling/
+
+    Works for direct connection to specific hosts.
+
+        Spark   : http://localhost:3000/
+        Grafana : http://localhost:8088/
+
+        Doesn't work for Spark UI URLs pointing to nodes inside the cluster.
+
+    #
+    # Run Firefox in a container.
+    # https://hub.docker.com/r/linuxserver/firefox/
+    # https://hub.docker.com/r/jlesage/firefox
+
+        Run Firefox in a container, configured
+        to use a SOCKS proxy to the cluster.
+
+    #
+    # Use FoxyProxy plugin to configure a SOCK proxy.
+    # https://addons.mozilla.org/en-US/firefox/addon/foxyproxy-standard/
+
+    #
+    # Configure SSH to create a SOCKS proxy.
+    # https://www.digitalocean.com/community/tutorials/how-to-route-web-traffic-securely-without-a-vpn-using-a-socks-tunnel
+
+
+
+# -----------------------------------------------------
+# Setup the SSH tunnel connection.
+# https://linuxize.com/post/how-to-setup-ssh-tunneling/
+# Running 'htop' on the Zeppelin node to keep the connection alive.
+#[user@desktop]
+
+    podman exec \
+        --tty \
+        --interactive \
+        ansibler \
+            bash -c \
+            '
+            ssh \
+                -t \
+                -L "3000:monitor:3000"  \
+                -L "8088:master01:8088" \
+                zeppelin \
+                    "
+                    htop
+                    "
+            '
+
+# -----------------------------------------------------
+# Detect and close any existing SSH connections.
+# https://unix.stackexchange.com/questions/24005/how-to-close-kill-ssh-controlmaster-connections-manually
+#[user@desktop]
+
+    ssh -O check zeppelin
+
+    >   Master running (pid=17663)
+
+
+    ssh -O exit zeppelin
+
+    >   Exit request sent.
+
+
+    ssh -O check zeppelin
+
+    >   Control socket connect(/root/.ssh/fedora@128.232.227.216:22): No such file or directory
+
+
+# -----------------------------------------------------
+# Setup a SSH tunnel SOCKS proxy.
+# https://www.digitalocean.com/community/tutorials/how-to-route-web-traffic-securely-without-a-vpn-using-a-socks-tunnel
+# Running with -v to add debug info.
+#[user@desktop]
+
+    podman exec \
+        --tty \
+        --interactive \
+        ansibler \
+            bash -c \
+            '
+            ssh \
+                -t \
+                -v \
+                -D "3000"  \
+                zeppelin \
+                    "
+                    bash
+                    "
+            '
+
+    >   ....
+    >   debug1: channel 5: new [dynamic-tcpip]
+    >   debug1: channel 6: free: direct-tcpip: listening port 3000 for master01 port 8088, connect from 127.0.0.1 port 42666 to 127.0.0.1 port 3000, nchannels 7
+    >   debug1: channel 5: free: direct-tcpip: listening port 3000 for worker06 port 8042, connect from 127.0.0.1 port 42670 to 127.0.0.1 port 3000, nchannels 6
+    >   debug1: Connection to port 3000 forwarding to socks port 0 requested.
+    >   debug1: channel 5: new [dynamic-tcpip]
+    >   debug1: channel 5: free: direct-tcpip: listening port 3000 for worker06 port 8042, connect from 127.0.0.1 port 42676 to 127.0.0.1 port 3000, nchannels 6
+    >   debug1: Connection to port 3000 forwarding to socks port 0 requested.
+    >   debug1: channel 5: new [dynamic-tcpip]
+    >   debug1: channel 5: free: direct-tcpip: listening port 3000 for worker06 port 8042, connect from 127.0.0.1 port 42680 to 127.0.0.1 port 3000, nchannels 6
+    >   ....
+
+
+# -----------------------------------------------------
+# Setup a SSH tunnel SOCKS proxy.
+# https://www.digitalocean.com/community/tutorials/how-to-route-web-traffic-securely-without-a-vpn-using-a-socks-tunnel
+# Running 'htop' on the Zeppelin node to keep the connection alive.
+#[user@desktop]
+
+    podman exec \
+        --tty \
+        --interactive \
+        ansibler \
+            bash -c \
+            '
+            ssh \
+                -t \
+                -D "3000"  \
+                zeppelin \
+                    "
+                    htop
+                    "
+            '
+
+
+# -----------------------------------------------------
+# Configure FoxyProxy to use our Proxy for our cluster nodes.
+#
+#[user@desktop]
+
+
+    # Install the plugin.
+    # https://addons.mozilla.org/en-US/firefox/addon/foxyproxy-standard/
+
+    # Import FoxyProxy settings
+    # moz-extension://####-####-####-####/import.html
+
+    {
+      "mode": "patterns",
+      "tx70qm1628251325009": {
+        "type": 3,
+        "color": "#66cc66",
+        "title": "Aglais SSH proxy",
+        "active": true,
+        "address": "localhost",
+        "port": 3000,
+        "proxyDNS": true,
+        "username": "",
+        "password": "",
+        "whitePatterns": [
+          {
+            "title": "Grafana metrics",
+            "pattern": "monitor:*",
+            "type": 1,
+            "protocols": 1,
+            "active": true
+          },
+          {
+            "title": "Zeppelin node",
+            "pattern": "zeppelin:*",
+            "type": 1,
+            "protocols": 1,
+            "active": true
+          },
+          {
+            "title": "Spark master",
+            "pattern": "master*:*",
+            "type": 1,
+            "protocols": 1,
+            "active": true
+          },
+          {
+            "title": "Spark workers",
+            "pattern": "worker*:*",
+            "type": 1,
+            "protocols": 1,
+            "active": true
+          }
+        ],
+        "blackPatterns": [],
+        "pacURL": "",
+        "index": 9007199254740990
+      }
+    }
+
+
+    # If importing the FoxyProxy settings doesn't work.
+    # Add configuration for a SOCKS proxy on port 3000.
+    # host: localhost
+    # port: 3000
+
+    # Add the hostname patterns to match
+
+    {
+      "whitePatterns": [
+        {
+          "title": "Grafana metrics",
+          "pattern": "monitor:*",
+          "type": 1,
+          "protocols": 1,
+          "active": true
+        },
+        {
+          "title": "Zeppelin node",
+          "pattern": "zeppelin:*",
+          "type": 1,
+          "protocols": 1,
+          "active": true
+        },
+        {
+          "title": "Spark master",
+          "pattern": "master*:*",
+          "type": 1,
+          "protocols": 1,
+          "active": true
+        },
+        {
+          "title": "Spark workers",
+          "pattern": "worker*:*",
+          "type": 1,
+          "protocols": 1,
+          "active": true
+        }
+      ],
+      "blackPatterns": []
+    }
+
+
+# -----------------------------------------------------
+# -----------------------------------------------------
+# Login to the Spark UI using Firefox.
+#[user@desktop]
+
+    firefox --new-window 'http://localhost:8088/' &
+
+    # Entry point for Hadoop cluster
+    http://localhost:8088/cluster
+
+    # Application cluster page
+    http://localhost:8088/cluster/app/application_1628007610214_0001
+
+    # Original application page
+    http://master01:8088/proxy/application_1628007610214_0001/
+
+    # Localhost application page
+    http://localhost:8088/proxy/application_1628007610214_0001/
+    http://localhost:8088/proxy/application_1628007610214_0001/executors/
+
+    # 12 executors, 4 cores each, 6.7G memory
+
+
+# -----------------------------------------------------
+# Login to Grafana using Firefox
+#[user@desktop]
+
+    firefox --new-window 'http://localhost:3000/login' &
+
+        user: admin
+        pass: admin
+
+
+    # Set new password in the next page
+        ########
+
+
+# -----------------------------------------------------
+# Add Prometheus Data Source
+# From Stelios's notes
+
+    # Click on button "Data Sources: Add your first data source"
+    # Select Prometheus as the Data source
+    # Set the url to: http://monitor:9090
+    # Set the Scrape interval to 5s
+
+
+# -----------------------------------------------------
+# Add standard Dashboard
+# From Stelios's notes
+
+    # Import Dashboards for Node Exporter metrics:
+    # https://grafana.com/grafana/dashboards/11074
+
+    # Edit the filesystem monitors.
+    # Several of the metrics limit the file system type 'fstype' to 'ext.*|xfs'
+    # Update this to 'ext.*|btrfs' to include the discs we created.
+
+    node_filesystem_free_bytes{instance=~'$node',fstype=~"ext.*|xfs",mountpoint !~".*pod.*"}
+    node_filesystem_free_bytes{instance=~'$node',fstype=~"ext.*|btrfs",mountpoint !~".*pod.*"}
+
+
+    # How to embed dashboards in our deploy ?
+
+
+# -----------------------------------------------------
+# Add our own Dashboard
+
+    # Import from JSON file.
+    # 20210705-02-grafana-dash.txt
+    # How to embed dashboards in our deploy ?
+
+
+# -----------------------------------------------------
+# Remove the port number from a graph legend.
+
+
+    https://stackoverflow.com/questions/47293510/grafana-legend-format-9100-removal
+    https://stackoverflow.com/a/49038198
+
+    label_replace(
+        (... original; query ...),
+        "hostname",
+        "$1",
+        "instance",
+        "(.*):.*"
+        )
+
+
+

--- a/notes/zrq/20210817-01-metrics-connect.txt
+++ b/notes/zrq/20210817-01-metrics-connect.txt
@@ -1,0 +1,198 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2021, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+#zrq-notes-time
+#zrq-notes-indent
+#zrq-notes-crypto
+#zrq-notes-ansible
+#zrq-notes-osformat
+#zrq-notes-zeppelin
+#
+
+    Target:
+
+        Re-connect to a running system and check the metrics.
+
+    Result:
+
+        Success.
+
+        TODO Save and restore the deployment config.
+
+        TODO Look at an alternative config using a direct ssh connection,
+        removing the requirement for using the docker client container.
+
+
+# -----------------------------------------------------
+# Checkout this branch.
+#[user@desktop]
+
+    source "${HOME:?}/aglais.env"
+    pushd "${AGLAIS_CODE}"
+
+        git checkout '20210702-zrq-prometheus'
+
+    popd
+
+
+# -----------------------------------------------------
+# Create a container to work with.
+#[user@desktop]
+
+    source "${HOME:?}/aglais.env"
+
+    podman run \
+        --rm \
+        --tty \
+        --interactive \
+        --name ansibler \
+        --hostname ansibler \
+        --publish 3000:3000 \
+        --publish 8088:8088 \
+        --env "SSH_AUTH_SOCK=/mnt/ssh_auth_sock" \
+        --volume "${SSH_AUTH_SOCK}:/mnt/ssh_auth_sock:rw,z" \
+        --volume "${HOME:?}/clouds.yaml:/etc/openstack/clouds.yaml:ro,z" \
+        --volume "${AGLAIS_CODE:?}/deployments:/deployments:ro,z" \
+        atolmis/ansible-client:2020.12.02 \
+        bash
+
+
+# -----------------------------------------------------
+# Set the target cloud.
+#[root@ansibler]
+
+    cloudname=gaia-dev
+
+
+# -----------------------------------------------------
+# Create our Ansible vars file.
+#[root@ansibler]
+
+    # TODO this should have been stored somewhere ..
+
+    configyml='/tmp/aglais-config.yml'
+    statusyml='/tmp/aglais-status.yml'
+
+    cat > "${statusyml:?}" << EOF
+aglais:
+     status:
+       deployment:
+         type: hadoop-yarn
+         conf: cclake-large-06
+         name: gaia-dev-20210805
+         date: 20210805T013241
+     spec:
+       openstack:
+         cloud: gaia-dev
+EOF
+
+    ln -sf \
+        "${statusyml:?}" \
+        '/tmp/ansible-vars.yml'
+
+
+# -----------------------------------------------------
+# Read the config settings.
+#[root@ansibler]
+
+    # TODO shell script to read these automatically
+
+    deployconf=$(
+        yq read \
+            "${statusyml:?}" \
+            'aglais.status.deployment.conf'
+        )
+
+    deployname=$(
+        yq read \
+            "${statusyml:?}" \
+            'aglais.status.deployment.name'
+        )
+
+    deploydate=$(
+        yq read \
+            "${statusyml:?}" \
+            'aglais.status.deployment.date'
+        )
+
+# -----------------------------------------------------
+# Delete any existing known hosts file..
+# Temp fix until we get a better solution.
+# https://github.com/wfau/aglais/issues/401
+#[root@ansibler]
+
+    rm -f "${HOME}/.ssh/known_hosts"
+
+
+# -----------------------------------------------------
+# Run the Ansible ssh playbook.
+#[root@ansibler]
+
+    pushd '/deployments/hadoop-yarn/ansible'
+
+        ansible-playbook \
+            --verbose \
+            --inventory "config/${deployconf}.yml" \
+            '05-config-ssh.yml'
+
+        ansible-playbook \
+            --verbose \
+            --inventory "config/${deployconf}.yml" \
+            "08-ping-test.yml"
+
+    popd
+
+
+# -----------------------------------------------------
+# -----------------------------------------------------
+# Setup a SSH tunnel SOCKS proxy.
+# https://www.digitalocean.com/community/tutorials/how-to-route-web-traffic-securely-without-a-vpn-using-a-socks-tunnel
+# Running 'htop' on the Zeppelin node to keep the connection alive.
+#[user@desktop]
+
+    podman exec \
+        --tty \
+        --interactive \
+        ansibler \
+            bash -c \
+            '
+            ssh \
+                -t \
+                -D "3000"  \
+                zeppelin \
+                    "
+                    htop
+                    "
+            '
+
+# -----------------------------------------------------
+# Login to the Spark UI using Firefox.
+#[user@desktop]
+
+    firefox --new-window 'http://master01:8088/cluster' &
+
+
+# -----------------------------------------------------
+# Login to Grafana using Firefox.
+#[user@desktop]
+
+    firefox --new-window 'http://monitor:3000/login' &
+
+

--- a/notes/zrq/20210817-02-metrics-connect.txt
+++ b/notes/zrq/20210817-02-metrics-connect.txt
@@ -1,0 +1,70 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2021, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+#zrq-notes-time
+#zrq-notes-indent
+#zrq-notes-crypto
+#zrq-notes-ansible
+#zrq-notes-osformat
+#zrq-notes-zeppelin
+#
+
+    Target:
+
+        Re-connect to a running system using a direct ssh connection and check the metrics.
+
+    Result:
+
+        Success.
+
+        TODO: Add internal DNS CNAME entries for 'sparkui', 'prometheus' and 'grafana'.
+
+
+# -----------------------------------------------------
+# Setup a SSH tunnel SOCKS proxy.
+# https://www.digitalocean.com/community/tutorials/how-to-route-web-traffic-securely-without-a-vpn-using-a-socks-tunnel
+# Running 'htop' on the Zeppelin node to keep the connection alive.
+#[user@desktop]
+
+    sshhost=zeppelin.gaia-dev.aglais.uk
+    sshuser=fedora
+
+    ssh "${sshuser:?}@${sshhost:?}" \
+        -t \
+        -D "3000"  \
+        zeppelin \
+            "
+            htop
+            "
+
+# -----------------------------------------------------
+# Login to the Spark UI using Firefox.
+#[user@desktop]
+
+    firefox --new-window 'http://master01:8088/cluster' &
+
+
+# -----------------------------------------------------
+# Login to Grafana using Firefox.
+#[user@desktop]
+
+    firefox --new-window 'http://monitor:3000/login' &
+
+


### PR DESCRIPTION
Using `ssh` to connect a SOCKS proxy from the local host to our zeppelin node, combined with the Firefox _FoxyProxy_ plugin configured to recognise our internal hostnames and route them via the proxy.