### PR TITLE
Added gaiaxpy installation to Hadoop deploy (using Ceph share)

### DIFF
--- a/deployments/hadoop-yarn/ansible/37-install-gaiaxpy.yml
+++ b/deployments/hadoop-yarn/ansible/37-install-gaiaxpy.yml
@@ -1,7 +1,7 @@
 #
 # <meta:header>
 #   <meta:licence>
-#     Copyright (c) 2021, ROE (http://www.roe.ac.uk/)
+#     Copyright (c) 2020, ROE (http://www.roe.ac.uk/)
 #
 #     This information is free software: you can redistribute it and/or modify
 #     it under the terms of the GNU General Public License as published by
@@ -19,25 +19,21 @@
 # </meta:header>
 #
 
-usershares:
+- name: "Install GaiaXpy"
+  hosts: masters:workers:zeppelin
+  gather_facts: false
+  vars_files:
+    - config/ansible.yml
+    - /tmp/ansible-vars.yml
 
-  - id: "nch"
-    sharename: "aglais-user-nch"
-    mountpath: "/user/nch"
 
-  - id: "zrq"
-    sharename: "aglais-user-zrq"
-    mountpath: "/user/zrq"
+  tasks:
 
-  - id: "stv"
-    sharename: "aglais-user-stv"
-    mountpath: "/user/stv"
+    - name: Install the required Python packages
+      become: true
+      command: "pip3 install -r /opt/software/GaiaXPy/requirements.txt"
 
-  - id: "dcr"
-    sharename: "aglais-user-dcr"
-    mountpath: "/user/dcr"
-
-  - id: "aglais-tools"
-    sharename: "aglais-tools"
-    mountpath: "/opt/software"
+    - name: Install GaiaXPy
+      become: true
+      command: "pip3 install  /opt/software/GaiaXPy/"
 

--- a/deployments/hadoop-yarn/bin/create-all.sh
+++ b/deployments/hadoop-yarn/bin/create-all.sh
@@ -323,3 +323,12 @@ then
     popd
 
 fi
+
+pushd "/deployments/hadoop-yarn/ansible"
+     ansible-playbook \
+        --verbose \
+        --inventory "${inventory:?}" \
+        "37-install-gaiaxpy.yml"
+popd
+
+

--- a/notes/stv/20211221-create-aglais-shares.txt
+++ b/notes/stv/20211221-create-aglais-shares.txt
@@ -1,0 +1,279 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2021, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+
+    Target:
+
+        Create Ceph share for test data
+
+    Result:
+
+        SUCCESS
+
+
+# -----------------------------------------------------
+# Checkout the deployment branch.
+#[user@desktop]
+
+    source "${HOME:?}/aglais.env"
+    pushd "${AGLAIS_CODE}"
+
+            git checkout 'issue-test-share'
+
+    popd
+
+
+# -----------------------------------------------------
+# Create a container to work with.
+#[user@desktop]
+
+   source "${HOME:?}/aglais.env"
+
+    AGLAIS_CLOUD=gaia-test
+
+    docker run \
+        --rm \
+        --tty \
+        --interactive \
+        --name ansibler2 \
+        --hostname ansibler \
+        --env "SSH_AUTH_SOCK=/mnt/ssh_auth_sock" \
+        --volume "${SSH_AUTH_SOCK}:/mnt/ssh_auth_sock:rw,z" \
+        --env "cloudname=${AGLAIS_CLOUD:?}" \
+        --volume "${HOME:?}/clouds.yaml:/etc/openstack/clouds.yaml:ro,z" \
+        --volume "${AGLAIS_CODE:?}/deployments:/deployments:ro,z" \
+        atolmis/ansible-client:2021.08.25 \
+        bash
+
+ 
+
+# -----------------------------------------------------
+# Set the Manila API version.
+# https://stackoverflow.com/a/58806536
+#[user@ansibler]
+
+    export OS_SHARE_API_VERSION=2.51
+
+
+
+# -----------------------------------------------------
+# List the existing shares.
+#[root@ansibler]
+
+    cloudname=gaia-prod
+
+    openstack \
+        --os-cloud "${cloudname:?}" \
+        share list
+
++--------------------------------------+-----------------------------+-------+-------------+-----------+-----------+------------------+------+-------------------+
+| ID                                   | Name                        |  Size | Share Proto | Status    | Is Public | Share Type Name  | Host | Availability Zone |
++--------------------------------------+-----------------------------+-------+-------------+-----------+-----------+------------------+------+-------------------+
+| 2e46b5a5-c5d9-44c0-b11c-310c222f4818 | aglais-data-gaia-dr2-6514   |   512 | CEPHFS      | available | True      | cephfsnativetype |      | nova              |
+| ca8231c3-1f5c-4ebf-8ec0-d3cfe2629976 | aglais-data-gaia-edr3-11932 |   540 | CEPHFS      | available | True      | cephfsnativetype |      | nova              |
+| d583565e-de86-46df-9969-f587e4d61a37 | aglais-data-gaia-edr3-2048  |  1024 | CEPHFS      | available | True      | cephfsnativetype |      | nova              |
+| 9d745a5b-7d98-421c-a16e-d1ac9fdeebc8 | aglais-data-gaia-edr3-4096  |  1024 | CEPHFS      | available | True      | cephfsnativetype |      | nova              |
+| 2e877d53-40b9-47e6-ae20-b6d3e1b9a9ae | aglais-data-gaia-edr3-8192  |  1024 | CEPHFS      | available | True      | cephfsnativetype |      | nova              |
+| ba66d6db-7d85-44c4-bb95-7410a000f6b7 | aglais-data-panstarrs-ps1   |   300 | CEPHFS      | available | True      | cephfsnativetype |      | nova              |
+| e65c0e26-957f-4ab0-94af-bb36b5a63285 | aglais-data-testing         |    10 | CEPHFS      | available | True      | cephfsnativetype |      | nova              |
+| 9dc3016a-f010-48bc-89fc-a9cbd688b7cc | aglais-data-twomass-allsky  |    40 | CEPHFS      | available | True      | cephfsnativetype |      | nova              |
+| 8f0b3452-3c66-4e65-8815-15eb73988b3e | aglais-data-wise-allwise    |   350 | CEPHFS      | available | True      | cephfsnativetype |      | nova              |
+| 7b03dcf9-6806-44a0-b87f-56528b50338f | aglais-user-dcr             |  1024 | CEPHFS      | available | True      | cephfsnativetype |      | nova              |
+| 6852b819-7395-4786-80c0-06fa9cebcc65 | aglais-user-nch             | 10240 | CEPHFS      | available | True      | cephfsnativetype |      | nova              |
+| fe63568a-d90c-4fb0-8979-07504328809d | aglais-user-stv             |  1024 | CEPHFS      | available | True      | cephfsnativetype |      | nova              |
+| ff351afd-1f06-4d02-9f53-cbe20b0676cc | aglais-user-zrq             |  1024 | CEPHFS      | available | True      | cephfsnativetype |      | nova              |
++--------------------------------------+-----------------------------+-------+-------------+-----------+-----------+------------------+------+-------------------+
+
+
+
+
+# -----------------------------------------------------
+# Create a new 1Tbyte share for Dennis.
+#[root@ansibler]
+
+    cloudname=gaia-prod
+    sharename=aglais-tools
+    mountpath=/tmp/aglais-tools
+
+    openstack \
+        --os-cloud "${cloudname:?}" \
+        share create \
+            --format json \
+            --name "${sharename:?}" \
+            --share-type 'cephfsnativetype' \
+            --availability-zone 'nova' \
+            'CEPHFS' \
+            1024 \
+    > "/tmp/${sharename:?}-share.json"
+
+    shareid=$(
+        jq -r '.id' "/tmp/${sharename:?}-share.json"
+        )
+
+
++---------------------------------------+---------------------------------------------------------------------------------------------------------------+
+| Field                                 | Value                                                                                                         |
++---------------------------------------+---------------------------------------------------------------------------------------------------------------+
+| access_rules_status                   | active                                                                                                        |
+| availability_zone                     | nova                                                                                                          |
+| create_share_from_snapshot_support    | False                                                                                                         |
+| created_at                            | 2021-12-21T15:51:01.000000                                                                                    |
+| description                           | None                                                                                                          |
+| export_locations                      |                                                                                                               |
+|                                       | path = 10.206.1.5:6789,10.206.1.6:6789,10.206.1.7:6789:/volumes/_nogroup/a1085a6d-cbfb-41e5-a408-52e2f33aa1c5 |
+|                                       | id = 7d801bef-9083-4be0-87f8-8d5358d803d0                                                                     |
+|                                       | preferred = False                                                                                             |
+| has_replicas                          | False                                                                                                         |
+| id                                    | eeb95821-f8f5-40d0-a04f-ea9cbf6e538b                                                                          |
+| is_public                             | False                                                                                                         |
+| mount_snapshot_support                | False                                                                                                         |
+| name                                  | aglais-tools                                                                                                  |
+| project_id                            | 21b4ae3a2ea44bc5a9c14005ed2963af                                                                              |
+| properties                            |                                                                                                               |
+| replication_type                      | None                                                                                                          |
+| revert_to_snapshot_support            | False                                                                                                         |
+| share_group_id                        | None                                                                                                          |
+| share_network_id                      | None                                                                                                          |
+| share_proto                           | CEPHFS                                                                                                        |
+| share_type                            | 5d0f58c5-ed21-4e1f-91bb-fe1a49deb5d8                                                                          |
+| share_type_name                       | cephfsnativetype                                                                                              |
+| size                                  | 1024                                                                                                          |
+| snapshot_id                           | None                                                                                                          |
+| snapshot_support                      | False                                                                                                         |
+| source_share_group_snapshot_member_id | None                                                                                                          |
+| status                                | available                                                                                                     |
+| task_state                            | None                                                                                                          |
+| user_id                               | afe12beb80594a368a7fc8b3f21b0943                                                                              |
+| volume_type                           | cephfsnativetype                                                                                              |
++---------------------------------------+---------------------------------------------------------------------------------------------------------------+
+
+
+
+
+# -----------------------------------------------------
+# Add a read-only access rule.
+#[root@ansibler]
+
+    openstack \
+        --os-cloud "${cloudname:?}" \
+        share access create \
+            --access-level 'ro' \
+            "${shareid:?}" \
+            'cephx' \
+            "${sharename:?}-ro"
+	
++--------------+--------------------------------------+
+| Field        | Value                                |
++--------------+--------------------------------------+
+| id           | e1fad0a2-0fc8-49b8-bc60-e3fc4379ce25 |
+| share_id     | eeb95821-f8f5-40d0-a04f-ea9cbf6e538b |
+| access_level | ro                                   |
+| access_to    | aglais-tools-ro                      |
+| access_type  | cephx                                |
+| state        | queued_to_apply                      |
+| access_key   | None                                 |
+| created_at   | 2021-12-21T15:54:48.000000           |
+| updated_at   | None                                 |
+| properties   |                                      |
++--------------+--------------------------------------+
+
+
+
+# -----------------------------------------------------
+# Add a read-write access rule.
+#[root@ansibler]
+
+
+    openstack \
+        --os-cloud "${cloudname:?}" \
+        share access create \
+            --access-level 'rw' \
+            "${shareid:?}" \
+            'cephx' \
+            "${sharename:?}-rw"
++--------------+--------------------------------------+
+| Field        | Value                                |
++--------------+--------------------------------------+
+| id           | 343f2225-1a50-4187-94de-5c33ed3a51ba |
+| share_id     | eeb95821-f8f5-40d0-a04f-ea9cbf6e538b |
+| access_level | rw                                   |
+| access_to    | aglais-tools-rw                      |
+| access_type  | cephx                                |
+| state        | queued_to_apply                      |
+| access_key   | None                                 |
+| created_at   | 2021-12-21T15:56:13.000000           |
+| updated_at   | None                                 |
+| properties   |                                      |
++--------------+--------------------------------------+
+
+
+# -----------------------------------------------------
+# Make the share public.
+#[root@ansibler]
+
+    openstack \
+        --os-cloud "${cloudname:?}" \
+        share set \
+            --public 'True' \
+            "${shareid:?}"
+
+
+    openstack \
+        --os-cloud "${cloudname:?}" \
+            share show \
+                "${shareid:?}"
++---------------------------------------+---------------------------------------------------------------------------------------------------------------+
+| Field                                 | Value                                                                                                         |
++---------------------------------------+---------------------------------------------------------------------------------------------------------------+
+| access_rules_status                   | active                                                                                                        |
+| availability_zone                     | nova                                                                                                          |
+| create_share_from_snapshot_support    | False                                                                                                         |
+| created_at                            | 2021-12-21T15:51:01.000000                                                                                    |
+| description                           | None                                                                                                          |
+| export_locations                      |                                                                                                               |
+|                                       | path = 10.206.1.5:6789,10.206.1.6:6789,10.206.1.7:6789:/volumes/_nogroup/a1085a6d-cbfb-41e5-a408-52e2f33aa1c5 |
+|                                       | id = 7d801bef-9083-4be0-87f8-8d5358d803d0                                                                     |
+|                                       | preferred = False                                                                                             |
+| has_replicas                          | False                                                                                                         |
+| id                                    | eeb95821-f8f5-40d0-a04f-ea9cbf6e538b                                                                          |
+| is_public                             | True                                                                                                          |
+| mount_snapshot_support                | False                                                                                                         |
+| name                                  | aglais-tools                                                                                                  |
+| project_id                            | 21b4ae3a2ea44bc5a9c14005ed2963af                                                                              |
+| properties                            |                                                                                                               |
+| replication_type                      | None                                                                                                          |
+| revert_to_snapshot_support            | False                                                                                                         |
+| share_group_id                        | None                                                                                                          |
+| share_network_id                      | None                                                                                                          |
+| share_proto                           | CEPHFS                                                                                                        |
+| share_type                            | 5d0f58c5-ed21-4e1f-91bb-fe1a49deb5d8                                                                          |
+| share_type_name                       | cephfsnativetype                                                                                              |
+| size                                  | 1024                                                                                                          |
+| snapshot_id                           | None                                                                                                          |
+| snapshot_support                      | False                                                                                                         |
+| source_share_group_snapshot_member_id | None                                                                                                          |
+| status                                | available                                                                                                     |
+| task_state                            | None                                                                                                          |
+| user_id                               | afe12beb80594a368a7fc8b3f21b0943                                                                              |
+| volume_type                           | cephfsnativetype                                                                                              |
++---------------------------------------+---------------------------------------------------------------------------------------------------------------+
+
+

--- a/notes/stv/20211222-setup-gaiaxpy-share.txt
+++ b/notes/stv/20211222-setup-gaiaxpy-share.txt
@@ -1,0 +1,165 @@
+
+  
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2021, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+
+    Target:
+
+        Setup Gaiaxpy on Ceph share
+
+
+    Result:
+
+        Success
+
+
+# -----------------------------------------------------
+# Fetch target branch
+#[user@desktop]
+
+    source "${HOME:?}/aglais.env"
+    pushd "${AGLAIS_CODE}"
+      	git checkout 'issue/574-gaiaxpy'
+    popd
+
+	
+
+
+
+# -----------------------------------------------------
+# Create a container to work with.
+#[user@desktop]
+
+    source "${HOME:?}/aglais.env"
+
+    docker run \
+        --rm \
+        --tty \
+        --interactive \
+        --name ansibler \
+        --hostname ansibler \
+        --publish 3000:3000 \
+        --publish 8088:8088 \
+        --env "SSH_AUTH_SOCK=/mnt/ssh_auth_sock" \
+        --volume "${SSH_AUTH_SOCK}:/mnt/ssh_auth_sock:rw,z" \
+        --volume "${HOME:?}/clouds.yaml:/etc/openstack/clouds.yaml:ro,z" \
+        --volume "${AGLAIS_CODE:?}/deployments:/deployments:ro,z" \
+        atolmis/ansible-client:2021.08.25 \
+        bash
+
+
+# -----------------------------------------------------
+# Set the target cloud.
+#[root@ansibler]
+
+    cloudname=gaia-test
+
+
+# -----------------------------------------------------
+# Delete everything.
+#[root@ansibler]
+
+    time \
+        /deployments/openstack/bin/delete-all.sh \
+            "${cloudname:?}"
+
+	> Done
+
+
+
+# -----------------------------------------------------
+# Create everything, using a standard config.
+#[root@ansibler]
+
+ 
+   time \
+      /deployments/hadoop-yarn/bin/create-all.sh  \
+         "${cloudname:?}" \
+         'cclake-medium-04'
+
+   > Done
+
+
+# -----------------------------------------------------
+# Checkout Gaiaxpy localy
+
+svn checkout https://gaia.esac.esa.int/dpacsvn/DPAC/DPCI/software/tools/GaiaXPy/
+
+
+# -----------------------------------------------------
+# Copy GaiaXpy from local to Zeppelin node
+# [user@local]
+ 
+  scp -r  GaiaXPy/ fedora@128.232.227.128:/home/fedora
+ 
+
+# Copy GaiaXpy to the share
+# -----------------------------------------------------
+# [fedora@zeppelin]
+
+ sudo cp -r  GaiaXPy/ /tmp/aglais-tools/
+
+ ls -al /tmp/aglais-tools/
+
+ > total 4
+ > drwxr-xr-x   3 root   root    1 Dec 22 18:10 .
+ > drwxrwxrwt. 14 root   root 4096 Dec 22 18:09 ..
+ > drwxrwxrwx   5 fedora root    9 Dec 22 18:10 GaiaXPy
+
+
+# -----------------------------------------------------
+# Set Permissions
+
+sudo chmod 777 -R GaiaXPy/
+sudo chown fedora:root -R GaiaXPy/
+
+
+..
+
+
+# ---------------------------------------------------------------------------------------------
+# Create a MANIFEST file, and alter setup.py script to include config directory in installation
+# [fedora@zeppelin]
+
+
+# After an an initial installation, it seems to be the case that gaiaxpy looks for files in config:
+#  gaiaxpy/config/
+# Which is not available in the installed package directory, so we get an error.
+
+# The following seems to have worked:
+
+nano /tmp/aglais-tools/GaiaXPy/gaiaxpy/MANIFEST.in
+..
+recursive-include gaiaxpy/config *
+..
+
+
+# Add a flag for include_package_data = True in setup
+
+nano /tmp/aglais-tools/GaiaXPy/gaiaxpy/setup.py
+..
+   packages=find_packages(),
+   include_package_data=True,
+..
+
+
+

--- a/notes/stv/20211223-gaiaxpy-test-deploy.txt
+++ b/notes/stv/20211223-gaiaxpy-test-deploy.txt
@@ -1,0 +1,111 @@
+
+  
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2021, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+
+    Target:
+
+        Test new deploy, which includes Gaiaxpy
+
+
+    Result:
+
+        Success
+
+
+# -----------------------------------------------------
+# Fetch target branch
+#[user@desktop]
+
+    source "${HOME:?}/aglais.env"
+    pushd "${AGLAIS_CODE}"
+      	git checkout 'issue/574-gaiaxpy'
+    popd
+
+	
+
+
+
+# -----------------------------------------------------
+# Create a container to work with.
+#[user@desktop]
+
+    source "${HOME:?}/aglais.env"
+
+    docker run \
+        --rm \
+        --tty \
+        --interactive \
+        --name ansibler \
+        --hostname ansibler \
+        --publish 3000:3000 \
+        --publish 8088:8088 \
+        --env "SSH_AUTH_SOCK=/mnt/ssh_auth_sock" \
+        --volume "${SSH_AUTH_SOCK}:/mnt/ssh_auth_sock:rw,z" \
+        --volume "${HOME:?}/clouds.yaml:/etc/openstack/clouds.yaml:ro,z" \
+        --volume "${AGLAIS_CODE:?}/deployments:/deployments:ro,z" \
+        atolmis/ansible-client:2021.08.25 \
+        bash
+
+
+# -----------------------------------------------------
+# Set the target cloud.
+#[root@ansibler]
+
+    cloudname=gaia-test
+
+
+# -----------------------------------------------------
+# Delete everything.
+#[root@ansibler]
+
+    time \
+        /deployments/openstack/bin/delete-all.sh \
+            "${cloudname:?}"
+
+	> Done
+
+
+
+# -----------------------------------------------------
+# Create everything, using a standard config.
+#[root@ansibler]
+
+ 
+   time \
+      /deployments/hadoop-yarn/bin/create-all.sh  \
+         "${cloudname:?}" \
+         'cclake-medium-04'
+
+   > Done
+
+
+# -----------------------------------------------------
+# Open new Spark notebook in Zeppelin 
+#[user@zeppelin]
+
+%pyspark
+
+import gaiaxpy
+> Took 34 sec. Last updated by admin at December 23 2021, 7:07:57 PM.
+
+


### PR DESCRIPTION
Includes an Ansible playbook to install gaiaxypy (from a Ceph share created to store proprietary software like this), and documentation on how the Ceph share was setup, as well as a test deploy.