### PR TITLE
Store notebooks in Ceph share

### DIFF
--- a/deployments/common/manila/usershares.yaml
+++ b/deployments/common/manila/usershares.yaml
@@ -41,6 +41,12 @@ usershares:
     sharename: "aglais-test-data"
     mountpath: "/user/test"
 
-- id: "aglais-tools"
+  - id: "aglais-tools"
     sharename: "aglais-tools"
     mountpath: "/opt/software"
+
+  - id: "aglais-notebooks"
+    sharename: "aglais-notebooks"
+    mountpath: "/home/fedora/zeppelin-0.10.0-bin-all/notebook/"
+
+

--- a/deployments/hadoop-yarn/bin/create-all.sh
+++ b/deployments/hadoop-yarn/bin/create-all.sh
@@ -305,6 +305,23 @@
 
     done
 
+
+# -----------------------------------------------------
+# Restart the Zeppelin service.
+
+    "${treetop:?}/hadoop-yarn/bin/restart-zeppelin.sh"
+
+# -----------------------------------------------------
+# Install GaiaXpy
+
+pushd "/deployments/hadoop-yarn/ansible"
+     ansible-playbook \
+        --verbose \
+        --inventory "${inventory:?}" \
+        "37-install-gaiaxpy.yml"
+popd
+
+
 # -----------------------------------------------------
 # Run Benchmarks
 
@@ -321,21 +338,4 @@ then
     popd
 
 fi
-
-# -----------------------------------------------------
-# Install GaiaXpy
-
-pushd "/deployments/hadoop-yarn/ansible"
-     ansible-playbook \
-        --verbose \
-        --inventory "${inventory:?}" \
-        "37-install-gaiaxpy.yml"
-popd
-
-
-
-# -----------------------------------------------------
-# Restart the Zeppelin service.
-
-    "${treetop:?}/hadoop-yarn/bin/restart-zeppelin.sh"
 

--- a/deployments/hadoop-yarn/bin/create-all.sh
+++ b/deployments/hadoop-yarn/bin/create-all.sh
@@ -322,6 +322,9 @@ then
 
 fi
 
+# -----------------------------------------------------
+# Install GaiaXpy
+
 pushd "/deployments/hadoop-yarn/ansible"
      ansible-playbook \
         --verbose \
@@ -329,4 +332,10 @@ pushd "/deployments/hadoop-yarn/ansible"
         "37-install-gaiaxpy.yml"
 popd
 
+
+
+# -----------------------------------------------------
+# Restart the Zeppelin service.
+
+    "${treetop:?}/hadoop-yarn/bin/restart-zeppelin.sh"
 

--- a/deployments/hadoop-yarn/bin/restart-zeppelin.sh
+++ b/deployments/hadoop-yarn/bin/restart-zeppelin.sh
@@ -1,0 +1,25 @@
+
+# -----------------------------------------------------
+# Settings ...
+
+    binfile="$(basename ${0})"
+    binpath="$(dirname $(readlink -f ${0}))"
+    srcpath="$(dirname ${binpath})"
+
+    echo ""
+    echo "---- ---- ----"
+    echo "File [${binfile}]"
+    echo "Path [${binpath}]"
+
+# -----------------------------------------------------
+# Start the Zeppelin service.
+
+    echo ""
+    echo "---- ----"
+    echo "Restarting Zeppelin"
+
+    ssh zeppelin \
+        '
+        /home/fedora/zeppelin-0.10.0-bin-all/bin/zeppelin-daemon.sh restart
+        '
+

--- a/notes/stv/20211223-gaiaxpy-test-deploy.txt
+++ b/notes/stv/20211223-gaiaxpy-test-deploy.txt
@@ -1,5 +1,3 @@
-
-  
 #
 # <meta:header>
 #   <meta:licence>

--- a/notes/stv/20211231-notebook-share.txt
+++ b/notes/stv/20211231-notebook-share.txt
@@ -1,0 +1,261 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2021, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+
+    source "${HOME:?}/aglais.env"
+
+    AGLAIS_CLOUD=gaia-test
+
+    docker run \
+        --rm \
+        --tty \
+        --interactive \
+        --name ansibler2 \
+        --hostname ansibler \
+        --env "SSH_AUTH_SOCK=/mnt/ssh_auth_sock" \
+        --volume "${SSH_AUTH_SOCK}:/mnt/ssh_auth_sock:rw,z" \
+        --env "cloudname=${AGLAIS_CLOUD:?}" \
+        --volume "${HOME:?}/clouds.yaml:/etc/openstack/clouds.yaml:ro,z" \
+        --volume "${AGLAIS_CODE:?}/deployments:/deployments:ro,z" \
+        atolmis/ansible-client:2021.08.25 \
+        bash
+
+ 
+
+# -----------------------------------------------------
+# Set the Manila API version.
+# https://stackoverflow.com/a/58806536
+#[user@ansibler]
+
+    export OS_SHARE_API_VERSION=2.51
+
+
+
+# -----------------------------------------------------
+# List the existing shares.
+#[root@ansibler]
+
+    cloudname=gaia-prod
+
+    openstack \
+        --os-cloud "${cloudname:?}" \
+        share list
+
++--------------------------------------+-----------------------------+-------+-------------+-----------+-----------+------------------+------+-------------------+
+| ID                                   | Name                        |  Size | Share Proto | Status    | Is Public | Share Type Name  | Host | Availability Zone |
++--------------------------------------+-----------------------------+-------+-------------+-----------+-----------+------------------+------+-------------------+
+| 2e46b5a5-c5d9-44c0-b11c-310c222f4818 | aglais-data-gaia-dr2-6514   |   512 | CEPHFS      | available | True      | cephfsnativetype |      | nova              |
+| ca8231c3-1f5c-4ebf-8ec0-d3cfe2629976 | aglais-data-gaia-edr3-11932 |   540 | CEPHFS      | available | True      | cephfsnativetype |      | nova              |
+| d583565e-de86-46df-9969-f587e4d61a37 | aglais-data-gaia-edr3-2048  |  1024 | CEPHFS      | available | True      | cephfsnativetype |      | nova              |
+| 9d745a5b-7d98-421c-a16e-d1ac9fdeebc8 | aglais-data-gaia-edr3-4096  |  1024 | CEPHFS      | available | True      | cephfsnativetype |      | nova              |
+| 2e877d53-40b9-47e6-ae20-b6d3e1b9a9ae | aglais-data-gaia-edr3-8192  |  1024 | CEPHFS      | available | True      | cephfsnativetype |      | nova              |
+| ba66d6db-7d85-44c4-bb95-7410a000f6b7 | aglais-data-panstarrs-ps1   |   300 | CEPHFS      | available | True      | cephfsnativetype |      | nova              |
+| e65c0e26-957f-4ab0-94af-bb36b5a63285 | aglais-data-testing         |    10 | CEPHFS      | available | True      | cephfsnativetype |      | nova              |
+| 9dc3016a-f010-48bc-89fc-a9cbd688b7cc | aglais-data-twomass-allsky  |    40 | CEPHFS      | available | True      | cephfsnativetype |      | nova              |
+| 8f0b3452-3c66-4e65-8815-15eb73988b3e | aglais-data-wise-allwise    |   350 | CEPHFS      | available | True      | cephfsnativetype |      | nova              |
+| 17310ca5-c9a6-43bb-987b-de543d453535 | aglais-test-data            |  1024 | CEPHFS      | available | True      | cephfsnativetype |      | nova              |
+| eeb95821-f8f5-40d0-a04f-ea9cbf6e538b | aglais-tools                |  1024 | CEPHFS      | available | True      | cephfsnativetype |      | nova              |
+| 7b03dcf9-6806-44a0-b87f-56528b50338f | aglais-user-dcr             |  1024 | CEPHFS      | available | True      | cephfsnativetype |      | nova              |
+| 6852b819-7395-4786-80c0-06fa9cebcc65 | aglais-user-nch             | 10240 | CEPHFS      | available | True      | cephfsnativetype |      | nova              |
+| fe63568a-d90c-4fb0-8979-07504328809d | aglais-user-stv             |  1024 | CEPHFS      | available | True      | cephfsnativetype |      | nova              |
+| ff351afd-1f06-4d02-9f53-cbe20b0676cc | aglais-user-zrq             |  1024 | CEPHFS      | available | True      | cephfsnativetype |      | nova              |
++--------------------------------------+-----------------------------+-------+-------------+-----------+-----------+------------------+------+-------------------+
+
+
+
+
+# -----------------------------------------------------
+# Create a new 4Tbyte share for notebooks.
+#[root@ansibler]
+
+    cloudname=gaia-prod
+    sharename=aglais-notebooks
+    mountpath=/opt/notebooks
+
+    openstack \
+        --os-cloud "${cloudname:?}" \
+        share create \
+            --format json \
+            --name "${sharename:?}" \
+            --share-type 'cephfsnativetype' \
+            --availability-zone 'nova' \
+            'CEPHFS' \
+            4096 \
+    > "/tmp/${sharename:?}-share.json"
+
+    shareid=$(
+        jq -r '.id' "/tmp/${sharename:?}-share.json"
+        )
+
+    openstack \
+        --os-cloud "${cloudname:?}" \
+            share show \
+                "${shareid:?}"
++---------------------------------------+---------------------------------------------------------------------------------------------------------------+
+| Field                                 | Value                                                                                                         |
++---------------------------------------+---------------------------------------------------------------------------------------------------------------+
+| access_rules_status                   | active                                                                                                        |
+| availability_zone                     | nova                                                                                                          |
+| create_share_from_snapshot_support    | False                                                                                                         |
+| created_at                            | 2021-12-31T13:23:09.000000                                                                                    |
+| description                           | None                                                                                                          |
+| export_locations                      |                                                                                                               |
+|                                       | path = 10.206.1.5:6789,10.206.1.6:6789,10.206.1.7:6789:/volumes/_nogroup/b29c958d-5a29-44f7-a974-b79b550f08f8 |
+|                                       | id = 189c04bf-3783-473c-a559-8dd39d4e1e82                                                                     |
+|                                       | preferred = False                                                                                             |
+| has_replicas                          | False                                                                                                         |
+| id                                    | f5a4b81d-a418-406b-bab0-7fb817bc8795                                                                          |
+| is_public                             | False                                                                                                         |
+| mount_snapshot_support                | False                                                                                                         |
+| name                                  | aglais-notebooks                                                                                              |
+| project_id                            | 21b4ae3a2ea44bc5a9c14005ed2963af                                                                              |
+| properties                            |                                                                                                               |
+| replication_type                      | None                                                                                                          |
+| revert_to_snapshot_support            | False                                                                                                         |
+| share_group_id                        | None                                                                                                          |
+| share_network_id                      | None                                                                                                          |
+| share_proto                           | CEPHFS                                                                                                        |
+| share_type                            | 5d0f58c5-ed21-4e1f-91bb-fe1a49deb5d8                                                                          |
+| share_type_name                       | cephfsnativetype                                                                                              |
+| size                                  | 4096                                                                                                          |
+| snapshot_id                           | None                                                                                                          |
+| snapshot_support                      | False                                                                                                         |
+| source_share_group_snapshot_member_id | None                                                                                                          |
+| status                                | available                                                                                                     |
+| task_state                            | None                                                                                                          |
+| user_id                               | afe12beb80594a368a7fc8b3f21b0943                                                                              |
+| volume_type                           | cephfsnativetype                                                                                              |
++---------------------------------------+---------------------------------------------------------------------------------------------------------------+
+
+
+
+
+# -----------------------------------------------------
+# Add a read-only access rule.
+#[root@ansibler]
+
+    openstack \
+        --os-cloud "${cloudname:?}" \
+        share access create \
+            --access-level 'ro' \
+            "${shareid:?}" \
+            'cephx' \
+            "${sharename:?}-ro"
+
++--------------+--------------------------------------+
+| Field        | Value                                |
++--------------+--------------------------------------+
+| id           | b8029c65-b65a-4890-bf2a-51510a122a17 |
+| share_id     | f5a4b81d-a418-406b-bab0-7fb817bc8795 |
+| access_level | ro                                   |
+| access_to    | aglais-notebooks-ro                  |
+| access_type  | cephx                                |
+| state        | queued_to_apply                      |
+| access_key   | None                                 |
+| created_at   | 2021-12-31T13:23:48.000000           |
+| updated_at   | None                                 |
+| properties   |                                      |
++--------------+--------------------------------------+
+
+
+
+
+# -----------------------------------------------------
+# Add a read-write access rule.
+#[root@ansibler]
+
+    openstack \
+        --os-cloud "${cloudname:?}" \
+        share access create \
+            --access-level 'rw' \
+            "${shareid:?}" \
+            'cephx' \
+            "${sharename:?}-rw"
+
++--------------+--------------------------------------+
+| Field        | Value                                |
++--------------+--------------------------------------+
+| id           | 02221816-2559-4076-97f2-711a54af5bb0 |
+| share_id     | f5a4b81d-a418-406b-bab0-7fb817bc8795 |
+| access_level | rw                                   |
+| access_to    | aglais-notebooks-rw                  |
+| access_type  | cephx                                |
+| state        | queued_to_apply                      |
+| access_key   | None                                 |
+| created_at   | 2021-12-31T13:23:58.000000           |
+| updated_at   | None                                 |
+| properties   |                                      |
++--------------+--------------------------------------+
+
+
+
+# -----------------------------------------------------
+# Make the share public.
+#[root@ansibler]
+
+    openstack \
+        --os-cloud "${cloudname:?}" \
+        share set \
+            --public 'True' \
+            "${shareid:?}"
+
+
+    openstack \
+        --os-cloud "${cloudname:?}" \
+            share show \
+                "${shareid:?}"
+
++---------------------------------------+---------------------------------------------------------------------------------------------------------------+
+| Field                                 | Value                                                                                                         |
++---------------------------------------+---------------------------------------------------------------------------------------------------------------+
+| access_rules_status                   | active                                                                                                        |
+| availability_zone                     | nova                                                                                                          |
+| create_share_from_snapshot_support    | False                                                                                                         |
+| created_at                            | 2021-12-31T13:23:09.000000                                                                                    |
+| description                           | None                                                                                                          |
+| export_locations                      |                                                                                                               |
+|                                       | path = 10.206.1.5:6789,10.206.1.6:6789,10.206.1.7:6789:/volumes/_nogroup/b29c958d-5a29-44f7-a974-b79b550f08f8 |
+|                                       | id = 189c04bf-3783-473c-a559-8dd39d4e1e82                                                                     |
+|                                       | preferred = False                                                                                             |
+| has_replicas                          | False                                                                                                         |
+| id                                    | f5a4b81d-a418-406b-bab0-7fb817bc8795                                                                          |
+| is_public                             | True                                                                                                          |
+| mount_snapshot_support                | False                                                                                                         |
+| name                                  | aglais-notebooks                                                                                              |
+| project_id                            | 21b4ae3a2ea44bc5a9c14005ed2963af                                                                              |
+| properties                            |                                                                                                               |
+| replication_type                      | None                                                                                                          |
+| revert_to_snapshot_support            | False                                                                                                         |
+| share_group_id                        | None                                                                                                          |
+| share_network_id                      | None                                                                                                          |
+| share_proto                           | CEPHFS                                                                                                        |
+| share_type                            | 5d0f58c5-ed21-4e1f-91bb-fe1a49deb5d8                                                                          |
+| share_type_name                       | cephfsnativetype                                                                                              |
+| size                                  | 4096                                                                                                          |
+| snapshot_id                           | None                                                                                                          |
+| snapshot_support                      | False                                                                                                         |
+| source_share_group_snapshot_member_id | None                                                                                                          |
+| status                                | available                                                                                                     |
+| task_state                            | None                                                                                                          |
+| user_id                               | afe12beb80594a368a7fc8b3f21b0943                                                                              |
+| volume_type                           | cephfsnativetype                                                                                              |
++---------------------------------------+---------------------------------------------------------------------------------------------------------------+
+

--- a/notes/stv/20220103-test-deploy-notebooks-ceph.txt
+++ b/notes/stv/20220103-test-deploy-notebooks-ceph.txt
@@ -1,0 +1,244 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2022, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+
+    Target:
+
+        Test new deploy, which mounts notebook directory from Ceph share
+
+
+    Result:
+
+        Success
+
+
+# -----------------------------------------------------
+# Fetch target branch
+#[user@desktop]
+
+    source "${HOME:?}/aglais.env"
+    pushd "${AGLAIS_CODE}"
+      	git checkout 'issue/613-notebook-share'
+    popd
+
+	
+
+
+
+# -----------------------------------------------------
+# Create a container to work with.
+#[user@desktop]
+
+    source "${HOME:?}/aglais.env"
+
+    docker run \
+        --rm \
+        --tty \
+        --interactive \
+        --name ansibler \
+        --hostname ansibler \
+        --publish 3000:3000 \
+        --publish 8088:8088 \
+        --env "SSH_AUTH_SOCK=/mnt/ssh_auth_sock" \
+        --volume "${SSH_AUTH_SOCK}:/mnt/ssh_auth_sock:rw,z" \
+        --volume "${HOME:?}/clouds.yaml:/etc/openstack/clouds.yaml:ro,z" \
+        --volume "${AGLAIS_CODE:?}/deployments:/deployments:ro,z" \
+        atolmis/ansible-client:2021.08.25 \
+        bash
+
+
+# -----------------------------------------------------
+# Set the target cloud.
+#[root@ansibler]
+
+    cloudname=gaia-test
+
+
+# -----------------------------------------------------
+# Delete everything.
+#[root@ansibler]
+
+    time \
+        /deployments/openstack/bin/delete-all.sh \
+            "${cloudname:?}"
+
+	> Done
+
+
+
+# -----------------------------------------------------
+# Create everything, using a standard config.
+#[root@ansibler]
+
+ 
+   time \
+      /deployments/hadoop-yarn/bin/create-all.sh  \
+         "${cloudname:?}" \
+         'cclake-medium-04'
+
+        > 
+
+	PLAY RECAP 
+        *******************************************************************************************************************
+	master01                   : ok=2    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+	worker01                   : ok=2    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+	worker02                   : ok=2    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+	worker03                   : ok=2    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+	worker04                   : ok=2    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+	zeppelin                   : ok=2    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+
+	/
+
+	---- ---- ----
+	File [restart-zeppelin.sh]
+	Path [/deployments/hadoop-yarn/bin]
+
+	---- ----
+	Restarting Zeppelin
+	Zeppelin stop                                              [  OK  ]
+	Zeppelin start                                             [  OK  ]
+
+	real	53m31.104s
+	user	13m10.768s
+	sys	3m26.662s
+
+
+
+# -----------------------------------------------------
+# Check notebook directory in Zeppelin 
+#[fedora@zeppelin]
+
+ls -al zeppelin-0.10.0-bin-all/notebook/
+	
+total 17127
+drwxrwxrwx   7 fedora root         18 Jan  2 20:09  .
+drwxr-xr-x. 14 fedora fedora     4096 Jan  3 11:51  ..
+drwxr-xr-x   2 fedora root          7 Jan  3 10:36  AglaisPublicExamples
+-rwxr-xr-x   1 fedora root     895331 Jan  2 20:09 'Bulk data loading_2GS4YGH4S.zpln'
+-rwxr-xr-x   1 fedora root     795339 Jan  2 20:09 'Bulk data loading by source ID_2GSDXABF6.zpln'
+-rwxr-xr-x   1 fedora root     251883 Jan  2 20:09  DR3-array-ingest-tests_2GQE5ZPW1.zpln
+drwxr-xr-x   5 fedora root          3 Jan  3 10:39  Experiments
+drwxrwxr-x   7 fedora root          7 Jan  2 11:41  .git
+-rwxr-xr-x   1 fedora root     778144 Jan  2 20:09 'Good astrometric solutions via ML Random Forrest classifier_2GSEFDUTU.zpln'
+-rwxr-xr-x   1 fedora root     166783 Jan  2 20:09 'Good astrometric solutions via Random Forrest classifier_2GRX8QP8J.zpln'
+-rwxr-xr-x   1 fedora root      12157 Jan  2 20:09 'Histogram plot_2GR6T52NA.zpln'
+-rwxr-xr-x   1 fedora root      38832 Jan  2 20:09 'Kounkel and Covey groups demo_2GQ4VB9YP.zpln'
+-rwxr-xr-x   1 fedora root      27183 Jan  2 20:09 'Kounkel & Covey Spark (Vectorized)_2GS5K9R39.zpln'
+-rwxr-xr-x   1 fedora root      39280 Jan  2 20:09 'Kounkel & Covey - UDF_2GSNDGD1T.zpln'
+-rwxr-xr-x   1 fedora root     625746 Jan  2 20:09 'Mean proper motions over the sky_2GSFCR1ZK.zpln'
+-rwxr-xr-x   1 fedora root   11495307 Jan  2 20:09  ML_cuts_2GS88QBR7.zpln
+drwxr-xr-x   2 fedora root          4 Dec 31 16:06 'Python Tutorial'
+-rwxr-xr-x   1 fedora root    1006107 Jan  2 20:09  QC_cuts_dev_2GRTNDM2Y.zpln
+drwxr-xr-x   2 fedora root          9 Dec 31 16:06 'Spark Tutorial'
+-rwxr-xr-x   1 fedora root    1398485 Jan  2 20:09  WD_detection_dev_2GRJFFQ39.zpln
+
+
+# -----------------------------------------------------
+# Open Zeppelin in browser
+#[user@zeppelin]
+
+
+# All notebooks show up as expected 
+
+# Run AglaisPublicExamples/SetUp [Success]
+# Run AglaisPublicExamples/Mean proper motions over the sky [Success]
+# Run AglaisPublicExamples/Source counts over the sky [Success]
+# Run AglaisPublicExamples/Good astrometric solutions via ML Random Forrest classifier [Success]
+
+
+
+# ---------------------------------------------------------------------
+# Create a new notebook, to validate that it persists after a redeploy
+#[user@zeppelin]
+
+# Create notebook: Experiments/stv/test1
+# Make some changes and commit to Zeppelin version control
+
+
+# Redeploy..
+
+
+
+# -----------------------------------------------------
+# Create a container to work with.
+#[user@desktop]
+
+    source "${HOME:?}/aglais.env"
+
+    docker run \
+        --rm \
+        --tty \
+        --interactive \
+        --name ansibler \
+        --hostname ansibler \
+        --publish 3000:3000 \
+        --publish 8088:8088 \
+        --env "SSH_AUTH_SOCK=/mnt/ssh_auth_sock" \
+        --volume "${SSH_AUTH_SOCK}:/mnt/ssh_auth_sock:rw,z" \
+        --volume "${HOME:?}/clouds.yaml:/etc/openstack/clouds.yaml:ro,z" \
+        --volume "${AGLAIS_CODE:?}/deployments:/deployments:ro,z" \
+        atolmis/ansible-client:2021.08.25 \
+        bash
+
+
+# -----------------------------------------------------
+# Set the target cloud.
+#[root@ansibler]
+
+    cloudname=gaia-test
+
+
+# -----------------------------------------------------
+# Delete everything.
+#[root@ansibler]
+
+    time \
+        /deployments/openstack/bin/delete-all.sh \
+            "${cloudname:?}"
+
+	> Done
+
+
+
+# -----------------------------------------------------
+# Create everything, using a standard config.
+#[root@ansibler]
+
+ 
+   time \
+      /deployments/hadoop-yarn/bin/create-all.sh  \
+         "${cloudname:?}" \
+         'cclake-medium-04'
+
+
+# ---------------------------------------------------------------------
+# Validate state of the new notebook
+#[user@zeppelin]
+
+# Notebook exists (Experiments/stv/test1)
+
+# Check commit history
+# Success, we see the full commit history of the file
+
+
+# This is expected, as Zeppelin creates a git repo, and the history is stored in the .git directory under "notebook/", which is what is stored in the Ceph share
+
+


### PR DESCRIPTION
Changes include:
- Notes on creating Ceph share for notebooks (4GB)
- Changes to deployment scripts to mount Ceph share as zeppelin/notebook directory
- Notes on testing deploy with Ceph mounted notebook share
- Script to restart Zeppelin after mounting notebooks

Closes #613 