### PR TITLE
Added benchmark output validation

### DIFF
--- a/deployments/hadoop-yarn/ansible/36-run-benchmark.yml
+++ b/deployments/hadoop-yarn/ansible/36-run-benchmark.yml
@@ -93,7 +93,7 @@
         state: present
 
     - pip:
-        name: 'git+https://github.com/wfau/aglais-testing@v0.1.8'
+        name: 'git+https://github.com/wfau/aglais-testing@v0.1.9'
         executable: pip
 
     - name: "Creating our Benchmarking script"

--- a/deployments/hadoop-yarn/ansible/36-run-benchmark.yml
+++ b/deployments/hadoop-yarn/ansible/36-run-benchmark.yml
@@ -93,7 +93,7 @@
         state: present
 
     - pip:
-        name: 'git+https://github.com/wfau/aglais-testing@v0.1.7'
+        name: 'git+https://github.com/wfau/aglais-testing@v0.1.8'
         executable: pip
 
     - name: "Creating our Benchmarking script"

--- a/deployments/hadoop-yarn/ansible/36-run-benchmark.yml
+++ b/deployments/hadoop-yarn/ansible/36-run-benchmark.yml
@@ -93,7 +93,7 @@
         state: present
 
     - pip:
-        name: 'git+https://github.com/wfau/aglais-testing@v0.2.0'
+        name: 'git+https://github.com/wfau/aglais-testing@v0.2.1'
         executable: pip
 
     - name: "Creating our Benchmarking script"

--- a/deployments/hadoop-yarn/ansible/36-run-benchmark.yml
+++ b/deployments/hadoop-yarn/ansible/36-run-benchmark.yml
@@ -93,7 +93,7 @@
         state: present
 
     - pip:
-        name: 'git+https://github.com/wfau/aglais-testing@v0.1.9'
+        name: 'git+https://github.com/wfau/aglais-testing@v0.2.0'
         executable: pip
 
     - name: "Creating our Benchmarking script"

--- a/deployments/hadoop-yarn/ansible/36-run-benchmark.yml
+++ b/deployments/hadoop-yarn/ansible/36-run-benchmark.yml
@@ -93,7 +93,7 @@
         state: present
 
     - pip:
-        name: 'git+https://github.com/wfau/aglais-testing@v0.1.5'
+        name: 'git+https://github.com/wfau/aglais-testing@v0.1.7'
         executable: pip
 
     - name: "Creating our Benchmarking script"

--- a/deployments/zeppelin/test/config/basic.json
+++ b/deployments/zeppelin/test/config/basic.json
@@ -1,36 +1,56 @@
 {
-"notebooks" : [
-           {
-              "name" : "SetUp",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/SetUp.json",
-              "totaltime" : 45,
-              "results" : []
-           },
-           {
-              "name" : "Mean_proper_motions_over_the_sky",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/Mean_proper_motions_over_the_sky.json",
-              "totaltime" : 55,
-              "results" : []
-           },
-           {
-              "name" : "Source_counts_over_the_sky.json",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/Source_counts_over_the_sky.json",
-              "totaltime" : 22,
-              "results" : []
-           },
-           {
-              "name" : "Good_astrometric_solutions_via_ML_Random_Forrest_classifier",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/Good_astrometric_solutions_via_ML_Random_Forrest_classifier.json",
-              "totaltime" : 500,
-              "results" : []
-           },
-           {
-              "name" : "Library_Validation.json",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/Library_validation.json",
-              "totaltime" : 60,
-              "results" : []
-           }
+	"notebooks": [{
+			"name": "SetUp",
+			"filepath": "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/SetUp.json",
+			"totaltime": 45,
+			"results": {}
+		},
+		{
+			"name": "Mean_proper_motions_over_the_sky",
+			"filepath": "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/Mean_proper_motions_over_the_sky.json",
+			"totaltime": 55,
+			"results": {
+				"0": "29b63ef48563f53e19460128434816e0",
+				"1": "cde34ea3444ec37766aa2cfa8ab72b77",
+				"2": "65226e852b7a3409a3e2afa7b41a6e5c",
+				"3": "1fb0ffc6caff1d5097a55ca6329d7b79"
+			}
+		},
+		{
+			"name": "Source_counts_over_the_sky.json",
+			"filepath": "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/Source_counts_over_the_sky.json",
+			"totaltime": 22,
+			"results": {
+				"0": "bf4788b1d0bb9e5c59c7e66bc38fb3c3",
+				"1": "e4f7595847377657dc7d38ca47e43b01",
+				"2": "65226e852b7a3409a3e2afa7b41a6e5c"
+			}
+
+		},
+		{
+			"name": "Good_astrometric_solutions_via_ML_Random_Forrest_classifier",
+			"filepath": "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/Good_astrometric_solutions_via_ML_Random_Forrest_classifier.json",
+			"totaltime": 500,
+			"results": {
+				"0": "03f0470f05b8c89d46b33b04ebe07709",
+				"1": "bb9ff4c82ed2c031288a72653ef79b5c",
+				"2": "92075fbeaef0f07734e2f853614ce8b7",
+				"3": "77a0e38c4bed8d548f1e8fc7575c1749",
+				"4": "075a56cc5b183fd1c199065dcb7ebb8a",
+				"5": "fce6eddff4fe32101e528091eb572e14",
+				"6": "98ff14cd2adf975fbb90e1c974900ff2",
+				"7": "c2f54d9986ea9f5f2a666b7c6505cc39",
+				"8": "ee3bdfc33b2631c2f6b3e107d7956a45",
+				"11": "68849c3723d8ab8e338d1b991bf681e1"
+			}
+		},
+		{
+			"name": "Library_Validation.json",
+			"filepath": "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/Library_validation.json",
+			"totaltime": 60,
+			"results": {}
+		}
 
 
-]
+	]
 }

--- a/deployments/zeppelin/test/config/basic.json
+++ b/deployments/zeppelin/test/config/basic.json
@@ -32,16 +32,16 @@
 			"filepath": "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/Good_astrometric_solutions_via_ML_Random_Forrest_classifier.json",
 			"totaltime": 500,
 			"results": {
-				"0": "03f0470f05b8c89d46b33b04ebe07709",
-				"1": "bb9ff4c82ed2c031288a72653ef79b5c",
-				"2": "92075fbeaef0f07734e2f853614ce8b7",
-				"3": "77a0e38c4bed8d548f1e8fc7575c1749",
-				"4": "075a56cc5b183fd1c199065dcb7ebb8a",
-				"5": "fce6eddff4fe32101e528091eb572e14",
-				"6": "98ff14cd2adf975fbb90e1c974900ff2",
-				"7": "c2f54d9986ea9f5f2a666b7c6505cc39",
-				"8": "ee3bdfc33b2631c2f6b3e107d7956a45",
-				"11": "68849c3723d8ab8e338d1b991bf681e1"
+                                "0": "03f0470f05b8c89d46b33b04ebe07709",
+                                "1": "bb9ff4c82ed2c031288a72653ef79b5c",
+                                "2": "92075fbeaef0f07734e2f853614ce8b7",
+                                "3": "77a0e38c4bed8d548f1e8fc7575c1749",
+                                "4": "075a56cc5b183fd1c199065dcb7ebb8a",
+                                "5": "fce6eddff4fe32101e528091eb572e14",
+                                "6": "98ff14cd2adf975fbb90e1c974900ff2",
+                                "7": "c2f54d9986ea9f5f2a666b7c6505cc39",
+                                "8": "ee3bdfc33b2631c2f6b3e107d7956a45",
+                                "11": "68849c3723d8ab8e338d1b991bf681e1"
 			}
 		},
 		{

--- a/deployments/zeppelin/test/config/full.json
+++ b/deployments/zeppelin/test/config/full.json
@@ -62,14 +62,13 @@
 			"filepath": "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/WD_detection_dev.json",
 			"totaltime": 3750,
 			"results": {
-				"0": "e6bd3499b7268442edae8efb5ccdbde8",
-				"1": "949d0f4f4af5ca0da949b737d0e32250",
-				"2": "c3079bff85e207bd09f93ffde8ff404d",
-				"3": "73ae611e9caae30f78afe5accbf848d9",
-				"4": "f2619c79da41f0e6ac7b9b86fca4052e",
-				"5": "7efbf82256050510a24670bc679d3674",
-				"6": "0c3e276442cac0eef0555d1a4d7afa08",
-				"7": "9c03842ae4ffe4ffeaa9c1bee5ddfccb"
+                                "0": "e6bd3499b7268442edae8efb5ccdbde8",
+                                "2": "c3079bff85e207bd09f93ffde8ff404d",
+                                "3": "73ae611e9caae30f78afe5accbf848d9",
+                                "4": "f2619c79da41f0e6ac7b9b86fca4052e",
+                                "5": "7efbf82256050510a24670bc679d3674",
+                                "6": "0c3e276442cac0eef0555d1a4d7afa08",
+                                "7": "9c03842ae4ffe4ffeaa9c1bee5ddfccb"
 			}
 		},
 		{
@@ -82,3 +81,4 @@
 
 	]
 }
+

--- a/deployments/zeppelin/test/config/full.json
+++ b/deployments/zeppelin/test/config/full.json
@@ -1,47 +1,84 @@
 {
-"notebooks" : [
-           {
-              "name" : "SetUp",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/SetUp.json",
-              "totaltime" : 45,
-              "results" : []
-           },
-           {
-              "name" : "Mean_proper_motions_over_the_sky",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/Mean_proper_motions_over_the_sky.json",
-              "totaltime" : 55,
-              "results" : []
-           },
-           {
-              "name" : "Source_counts_over_the_sky.json",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/Source_counts_over_the_sky.json",
-              "totaltime" : 22,
-              "results" : []
-           },
-           {
-              "name" : "Good_astrometric_solutions_via_ML_Random_Forrest_classifier",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/Good_astrometric_solutions_via_ML_Random_Forrest_classifier.json",
-              "totaltime" : 500,
-              "results" : []
-           },
-           {
-              "name" : "QC_cuts_dev.json",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/QC_cuts_dev.json",
-              "totaltime" : 4700,
-              "results" : []
-           },
-           {
-              "name" : "WD_detection_dev.json",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/WD_detection_dev.json",
-              "totaltime" : 3750,
-              "results" : []
-           },
-           {
-              "name" : "Library_Validation.json",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/Library_validation.json",
-              "totaltime" : 60,
-              "results" : []
-           }
+	"notebooks": [{
+			"name": "SetUp",
+			"filepath": "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/SetUp.json",
+			"totaltime": 45,
+			"results": {}
+		},
+		{
+			"name": "Mean_proper_motions_over_the_sky",
+			"filepath": "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/Mean_proper_motions_over_the_sky.json",
+			"totaltime": 55,
+			"results": {
+				"0": "29b63ef48563f53e19460128434816e0",
+				"1": "cde34ea3444ec37766aa2cfa8ab72b77",
+				"2": "65226e852b7a3409a3e2afa7b41a6e5c",
+				"3": "1fb0ffc6caff1d5097a55ca6329d7b79"
+			}
+		},
+		{
+			"name": "Source_counts_over_the_sky.json",
+			"filepath": "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/Source_counts_over_the_sky.json",
+			"totaltime": 22,
+			"results": {
+				"0": "bf4788b1d0bb9e5c59c7e66bc38fb3c3",
+				"1": "e4f7595847377657dc7d38ca47e43b01",
+				"2": "65226e852b7a3409a3e2afa7b41a6e5c"
+			}
 
-]
+		},
+		{
+			"name": "Good_astrometric_solutions_via_ML_Random_Forrest_classifier",
+			"filepath": "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/Good_astrometric_solutions_via_ML_Random_Forrest_classifier.json",
+			"totaltime": 500,
+			"results": {
+				"0": "03f0470f05b8c89d46b33b04ebe07709",
+				"1": "bb9ff4c82ed2c031288a72653ef79b5c",
+				"2": "92075fbeaef0f07734e2f853614ce8b7",
+				"3": "77a0e38c4bed8d548f1e8fc7575c1749",
+				"4": "075a56cc5b183fd1c199065dcb7ebb8a",
+				"5": "fce6eddff4fe32101e528091eb572e14",
+				"6": "98ff14cd2adf975fbb90e1c974900ff2",
+				"7": "c2f54d9986ea9f5f2a666b7c6505cc39",
+				"8": "ee3bdfc33b2631c2f6b3e107d7956a45",
+				"11": "68849c3723d8ab8e338d1b991bf681e1"
+			}
+		},
+		{
+			"name": "QC_cuts_dev.json",
+			"filepath": "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/QC_cuts_dev.json",
+			"totaltime": 4700,
+			"results": {
+				"0": "dd673404e0cf3c5f94520ac129d4be23",
+				"1": "390a0a30e858aea4538a8c5458eb1723",
+				"2": "926d8324f7db6eaa2f2494ee9c1f231a",
+				"3": "6665b6427171bf0aac7a52bf7d55c430",
+				"4": "ee48485cab930313ffb3bdd88c4a4a0f",
+				"5": "7bfaccdeb80e2cfe34c8f0b6b5a374fa"
+			}
+		},
+		{
+			"name": "WD_detection_dev.json",
+			"filepath": "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/WD_detection_dev.json",
+			"totaltime": 3750,
+			"results": {
+				"0": "e6bd3499b7268442edae8efb5ccdbde8",
+				"1": "949d0f4f4af5ca0da949b737d0e32250",
+				"2": "c3079bff85e207bd09f93ffde8ff404d",
+				"3": "73ae611e9caae30f78afe5accbf848d9",
+				"4": "f2619c79da41f0e6ac7b9b86fca4052e",
+				"5": "7efbf82256050510a24670bc679d3674",
+				"6": "0c3e276442cac0eef0555d1a4d7afa08",
+				"7": "9c03842ae4ffe4ffeaa9c1bee5ddfccb"
+			}
+		},
+		{
+			"name": "Library_Validation.json",
+			"filepath": "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/Library_validation.json",
+			"totaltime": 60,
+			"results": {}
+		}
+
+
+	]
 }

--- a/deployments/zeppelin/test/config/multiuser.json
+++ b/deployments/zeppelin/test/config/multiuser.json
@@ -1,36 +1,55 @@
 {
-"notebooks" : [
-           {
-              "name" : "SetUp",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/SetUp.json",
-              "totaltime" : 50,
-              "results" : []
-           },
-           {
-              "name" : "Mean_proper_motions_over_the_sky",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/Mean_proper_motions_over_the_sky.json",
-              "totaltime" : 65,
-              "results" : []
-           },
-           {
-              "name" : "Source_counts_over_the_sky.json",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/Source_counts_over_the_sky.json",
-              "totaltime" : 23,
-              "results" : []
-           },
-           {
-              "name" : "Good_astrometric_solutions_via_ML_Random_Forrest_classifier",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/Good_astrometric_solutions_via_ML_Random_Forrest_classifier.json",
-              "totaltime" : 800,
-              "results" : []
-           },
-           {
-              "name" : "Library_Validation.json",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/Library_validation.json",
-              "totaltime" : 60,
-              "results" : []
-           }
+	"notebooks": [{
+			"name": "SetUp",
+			"filepath": "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/SetUp.json",
+			"totaltime": 50,
+			"results": {}
+		},
+		{
+			"name": "Mean_proper_motions_over_the_sky",
+			"filepath": "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/Mean_proper_motions_over_the_sky.json",
+			"totaltime": 65,
+			"results": {
+				"0": "29b63ef48563f53e19460128434816e0",
+				"1": "cde34ea3444ec37766aa2cfa8ab72b77",
+				"2": "65226e852b7a3409a3e2afa7b41a6e5c",
+				"3": "1fb0ffc6caff1d5097a55ca6329d7b79"
+			}
+		},
+		{
+			"name": "Source_counts_over_the_sky.json",
+			"filepath": "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/Source_counts_over_the_sky.json",
+			"totaltime": 23,
+			"results": {
+				"0": "bf4788b1d0bb9e5c59c7e66bc38fb3c3",
+				"1": "e4f7595847377657dc7d38ca47e43b01",
+				"2": "65226e852b7a3409a3e2afa7b41a6e5c"
+			}
+		},
+		{
+			"name": "Good_astrometric_solutions_via_ML_Random_Forrest_classifier",
+			"filepath": "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/Good_astrometric_solutions_via_ML_Random_Forrest_classifier.json",
+			"totaltime": 800,
+			"results": {
+				"0": "03f0470f05b8c89d46b33b04ebe07709",
+				"1": "bb9ff4c82ed2c031288a72653ef79b5c",
+				"2": "92075fbeaef0f07734e2f853614ce8b7",
+				"3": "77a0e38c4bed8d548f1e8fc7575c1749",
+				"4": "075a56cc5b183fd1c199065dcb7ebb8a",
+				"5": "fce6eddff4fe32101e528091eb572e14",
+				"6": "98ff14cd2adf975fbb90e1c974900ff2",
+				"7": "c2f54d9986ea9f5f2a666b7c6505cc39",
+				"8": "ee3bdfc33b2631c2f6b3e107d7956a45",
+				"11": "68849c3723d8ab8e338d1b991bf681e1"
+			}
+		},
+		{
+			"name": "Library_Validation.json",
+			"filepath": "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/Library_validation.json",
+			"totaltime": 60,
+			"results": {}
+		}
 
 
-]
+	]
 }

--- a/deployments/zeppelin/test/config/multiuser.json
+++ b/deployments/zeppelin/test/config/multiuser.json
@@ -31,16 +31,16 @@
 			"filepath": "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/Good_astrometric_solutions_via_ML_Random_Forrest_classifier.json",
 			"totaltime": 800,
 			"results": {
-				"0": "03f0470f05b8c89d46b33b04ebe07709",
-				"1": "bb9ff4c82ed2c031288a72653ef79b5c",
-				"2": "92075fbeaef0f07734e2f853614ce8b7",
-				"3": "77a0e38c4bed8d548f1e8fc7575c1749",
-				"4": "075a56cc5b183fd1c199065dcb7ebb8a",
-				"5": "fce6eddff4fe32101e528091eb572e14",
-				"6": "98ff14cd2adf975fbb90e1c974900ff2",
-				"7": "c2f54d9986ea9f5f2a666b7c6505cc39",
-				"8": "ee3bdfc33b2631c2f6b3e107d7956a45",
-				"11": "68849c3723d8ab8e338d1b991bf681e1"
+                                "0": "03f0470f05b8c89d46b33b04ebe07709",
+                                "1": "bb9ff4c82ed2c031288a72653ef79b5c",
+                                "2": "92075fbeaef0f07734e2f853614ce8b7",
+                                "3": "77a0e38c4bed8d548f1e8fc7575c1749",
+                                "4": "075a56cc5b183fd1c199065dcb7ebb8a",
+                                "5": "fce6eddff4fe32101e528091eb572e14",
+                                "6": "98ff14cd2adf975fbb90e1c974900ff2",
+                                "7": "c2f54d9986ea9f5f2a666b7c6505cc39",
+                                "8": "ee3bdfc33b2631c2f6b3e107d7956a45",
+                                "11": "68849c3723d8ab8e338d1b991bf681e1"
 			}
 		},
 		{

--- a/deployments/zeppelin/test/config/quick.json
+++ b/deployments/zeppelin/test/config/quick.json
@@ -1,30 +1,39 @@
 {
-"notebooks" : [
-           {
-              "name" : "SetUp",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/SetUp.json",
-              "totaltime" : 45,
-              "results" : []
-           },
-           {
-              "name" : "Mean_proper_motions_over_the_sky",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/Mean_proper_motions_over_the_sky.json",
-              "totaltime" : 55,
-              "results" : []
-           },
-           {
-              "name" : "Source_counts_over_the_sky.json",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/Source_counts_over_the_sky.json",
-              "totaltime" : 22,
-              "results" : []
-           },
-           {
-              "name" : "Library_Validation.json",
-              "filepath" : "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/Library_validation.json",
-              "totaltime" : 60,
-              "results" : []
-           }
+	"notebooks": [{
+			"name": "SetUp",
+			"filepath": "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/SetUp.json",
+			"totaltime": 45,
+			"results": {}
+		},
+		{
+			"name": "Mean_proper_motions_over_the_sky",
+			"filepath": "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/Mean_proper_motions_over_the_sky.json",
+			"totaltime": 55,
+			"results": {
+				"0": "29b63ef48563f53e19460128434816e0",
+				"1": "cde34ea3444ec37766aa2cfa8ab72b77",
+				"2": "65226e852b7a3409a3e2afa7b41a6e5c",
+				"3": "1fb0ffc6caff1d5097a55ca6329d7b79"
+			}
+		},
+		{
+			"name": "Source_counts_over_the_sky.json",
+			"filepath": "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/Source_counts_over_the_sky.json",
+			"totaltime": 22,
+			"results": {
+				"0": "bf4788b1d0bb9e5c59c7e66bc38fb3c3",
+				"1": "e4f7595847377657dc7d38ca47e43b01",
+				"2": "65226e852b7a3409a3e2afa7b41a6e5c"
+			}
+
+		},
+		{
+			"name": "Library_Validation.json",
+			"filepath": "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/Library_validation.json",
+			"totaltime": 60,
+			"results": {}
+		}
 
 
-]
+	]
 }

--- a/notes/stv/20220228-benchmarks-01.txt
+++ b/notes/stv/20220228-benchmarks-01.txt
@@ -1,0 +1,184 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2022, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+
+    Target:
+
+        Run Test Deploy and Benchmarks, include validation of output
+
+    Result:
+  
+        SUCCESS (BUT SLOW)
+
+
+
+
+# -----------------------------------------------------
+# Fetch target branch
+#[user@desktop]
+
+    source "${HOME:?}/aglais.env"
+    pushd "${AGLAIS_CODE}"
+      	git checkout 'feature/upgrade-testing'
+
+    popd
+
+	
+
+# -----------------------------------------------------
+# Create a container to work with.
+#[user@desktop]
+
+    source "${HOME:?}/aglais.env"
+
+    podman run \
+        --rm \
+        --tty \
+        --interactive \
+        --name ansibler \
+        --hostname ansibler \
+        --publish 3000:3000 \
+        --publish 8088:8088 \
+        --env "SSH_AUTH_SOCK=/mnt/ssh_auth_sock" \
+        --volume "${SSH_AUTH_SOCK}:/mnt/ssh_auth_sock:rw,z" \
+        --volume "${HOME:?}/clouds.yaml:/etc/openstack/clouds.yaml:ro,z" \
+        --volume "${AGLAIS_CODE:?}/deployments:/deployments:ro,z" \
+        atolmis/ansible-client:2021.08.25 \
+        bash
+
+
+
+# -----------------------------------------------------
+# Set the cloud and configuration.
+#[root@ansibler]
+
+    cloudname=iris-gaia-red
+
+    configname=zeppelin-27.45-spark-6.27.45
+
+
+
+# -----------------------------------------------------
+# Delete everything.
+#[root@ansibler]
+
+    time \
+        /deployments/openstack/bin/delete-all.sh \
+            "${cloudname:?}"
+
+        > Done
+
+
+
+# -----------------------------------------------------
+# Create everything, using the new config.
+#[root@ansibler]
+
+    time \
+        /deployments/hadoop-yarn/bin/create-all.sh \
+            "${cloudname:?}" \
+            "${configname:?}"   \
+        | tee /tmp/create-all.log
+
+
+        > Done
+
+
+
+
+# -----------------------------------------------------
+# Run Full test
+#[root@ansibler]
+
+    num_users=1
+    concurrent=False
+    test_level=full
+ 
+
+    time \
+        /deployments/hadoop-yarn/bin/run-tests.sh \
+            "${cloudname:?}" \
+            "${configname:?}" \
+            "${test_level:?}"  \
+	     ${concurrent:?}  \
+	     ${num_users:?}  \
+        | tee /tmp/run-tests-full.log
+
+
+	> Done
+        > Success
+
+
+# Results: 
+
+
+[{
+	'SetUp': {
+		'totaltime': '43.86',
+		'status': 'SUCCESS',
+		'msg': '',
+		'valid': 'TRUE'
+	},
+	'Mean_proper_motions_over_the_sky': {
+		'totaltime': '48.57',
+		'status': 'SUCCESS',
+		'msg': '',
+		'valid': 'TRUE'
+	},
+	'Source_counts_over_the_sky.json': {
+		'totaltime': '20.45',
+		'status': 'SUCCESS',
+		'msg': '',
+		'valid': 'TRUE'
+	},
+	'Good_astrometric_solutions_via_ML_Random_Forrest_classifier': {
+		'totaltime': '557.22',
+		'status': 'SLOW',
+		'msg': '',
+		'valid': 'TRUE'
+	},
+	'QC_cuts_dev.json': {
+		'totaltime': '4703.75',
+		'status': 'SLOW',
+		'msg': '',
+		'valid': 'TRUE'
+	},
+	'WD_detection_dev.json': {
+		'totaltime': '4426.34',
+		'status': 'SLOW',
+		'msg': '',
+		'valid': 'TRUE'
+	},
+	'Library_Validation.json': {
+		'totaltime': '5.73',
+		'status': 'SUCCESS',
+		'msg': '',
+		'valid': 'TRUE'
+	}
+}]
+
+
+# Note that valid = TRUE, when the test configuration either:
+# a) Does not have any per cell checksums (md5 hash) to compare
+# or 
+# b) Has per cell checksums, and all match the output that the benchmarks produced 
+
+

--- a/notes/stv/20220304-test-deploy-validate-checksums.txt
+++ b/notes/stv/20220304-test-deploy-validate-checksums.txt
@@ -1,0 +1,271 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2022, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+
+    Target:
+
+        Run Test Deploy, and run benchmark, with and without modified (incorrect) checksums.
+        Validate that the tests pass/fail correctly accordingly
+
+    Result:
+  
+        SUCCESS
+
+
+
+
+# -----------------------------------------------------
+# Fetch target branch
+#[user@desktop]
+
+    source "${HOME:?}/aglais.env"
+    pushd "${AGLAIS_CODE}"
+      	git checkout 'feature/upgrade-testing'
+
+    popd
+
+
+
+
+# -----------------------------------------------------
+# Create a container to work with.
+#[user@desktop]
+
+    source "${HOME:?}/aglais.env"
+
+    podman run \
+        --rm \
+        --tty \
+        --interactive \
+        --name ansibler10 \
+        --hostname ansibler \
+        --publish 3000:3000 \
+        --publish 8088:8088 \
+        --env "SSH_AUTH_SOCK=/mnt/ssh_auth_sock" \
+        --volume "${SSH_AUTH_SOCK}:/mnt/ssh_auth_sock:rw,z" \
+        --volume "${HOME:?}/clouds.yaml:/etc/openstack/clouds.yaml:ro,z" \
+        --volume "${AGLAIS_CODE:?}/deployments:/deployments:ro,z" \
+        atolmis/ansible-client:2021.08.25 \
+        bash
+
+
+
+# -----------------------------------------------------
+# Set the cloud and configuration.
+#[root@ansibler]
+
+    cloudname=iris-gaia-red
+
+    configname=zeppelin-27.45-spark-6.27.45
+
+
+
+# -----------------------------------------------------
+# Delete everything.
+#[root@ansibler]
+
+    time \
+        /deployments/openstack/bin/delete-all.sh \
+            "${cloudname:?}"
+
+        > Done
+
+
+
+# -----------------------------------------------------
+# Create everything, using the new config.
+#[root@ansibler]
+
+    time \
+        /deployments/hadoop-yarn/bin/create-all.sh \
+            "${cloudname:?}" \
+            "${configname:?}"   \
+        | tee /tmp/create-all.log
+
+
+        > Done
+
+
+
+# -----------------------------------------------------
+# Run Quick test
+#[root@ansibler]
+
+    num_users=1
+    concurrent=False
+    test_level=quick
+
+    time \
+        /deployments/hadoop-yarn/bin/run-tests.sh \
+            "${cloudname:?}" \
+            "${configname:?}" \
+            "${test_level:?}"  \
+	     ${concurrent:?}  \
+	     ${num_users:?}  \
+        | tee /tmp/run-tests-quick.log
+
+
+TASK [Run benchmarker] **************************************************************************************************************************************************************************************
+changed: [localhost] => {"changed": true, "cmd": "python3 /tmp/run-test.py | tee /tmp/test-result.json", "delta": "0:01:59.048924", "end": "2022-03-04 14:14:11.271590", "rc": 0, "start": "2022-03-04 14:12:12.222666", "stderr": "", "stderr_lines": [], "stdout": "Test started [Single User]\nTest completed! (118.92 seconds)\n------------ Test Completion: [SLOW] ------------ Test Output: [VALID] ------------\n[{'SetUp': {'totaltime': '45.85', 'status': 'SLOW', 'msg': '', 'valid': 'TRUE'}, 'Mean_proper_motions_over_the_sky': {'totaltime': '45.52', 'status': 'SUCCESS', 'msg': '', 'valid': 'TRUE'}, 'Source_counts_over_the_sky.json': {'totaltime': '17.78', 'status': 'SUCCESS', 'msg': '', 'valid': 'TRUE'}, 'Library_Validation.json': {'totaltime': '9.78', 'status': 'SUCCESS', 'msg': '', 'valid': 'TRUE'}}]", "stdout_lines": ["Test started [Single User]", "Test completed! (118.92 seconds)", "------------ Test Completion: [SLOW] ------------ Test Output: [VALID] ------------", "[{'SetUp': {'totaltime': '45.85', 'status': 'SLOW', 'msg': '', 'valid': 'TRUE'}, 'Mean_proper_motions_over_the_sky': {'totaltime': '45.52', 'status': 'SUCCESS', 'msg': '', 'valid': 'TRUE'}, 'Source_counts_over_the_sky.json': {'totaltime': '17.78', 'status': 'SUCCESS', 'msg': '', 'valid': 'TRUE'}, 'Library_Validation.json': {'totaltime': '9.78', 'status': 'SUCCESS', 'msg': '', 'valid': 'TRUE'}}]"]}
+
+
+# Results (Formatted): 
+
+> ------------ Test Completion: [SLOW] ------------ Test Output: [VALID] ------------
+
+[{
+	'SetUp': {
+		'totaltime': '45.85',
+		'status': 'SLOW',
+		'msg': '',
+		'valid': 'TRUE'
+	},
+	'Mean_proper_motions_over_the_sky': {
+		'totaltime': '45.52',
+		'status': 'SUCCESS',
+		'msg': '',
+		'valid': 'TRUE'
+	},
+	'Source_counts_over_the_sky.json': {
+		'totaltime': '17.78',
+		'status': 'SUCCESS',
+		'msg': '',
+		'valid': 'TRUE'
+	},
+	'Library_Validation.json': {
+		'totaltime': '9.78',
+		'status': 'SUCCESS',
+		'msg': '',
+		'valid': 'TRUE'
+	}
+}]
+
+# ----------------
+---------------------------------------------
+# Change the quick.json notebook configuration
+# Modify the checksums, add a string to invalidate the checksum
+#[user@desktop]
+
+{
+        "notebooks": [{
+                        "name": "SetUp",
+                        "filepath": "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/SetUp.json",
+                        "totaltime": 45,
+                        "results": {}
+                },
+                {
+                        "name": "Mean_proper_motions_over_the_sky",
+                        "filepath": "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/Mean_proper_motions_over_the_sky.json",
+                        "totaltime": 55,
+                        "results": {
+                                "0": "FALSE29b63ef48563f53e19460128434816e0",
+                                "1": "cde34ea3444ec37766aa2cfa8ab72b77",
+                                "2": "65226e852b7a3409a3e2afa7b41a6e5c",
+                                "3": "1fb0ffc6caff1d5097a55ca6329d7b79"
+                        }
+                },
+                {
+                        "name": "Source_counts_over_the_sky.json",
+                        "filepath": "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/Source_counts_over_the_sky.json",
+                        "totaltime": 22,
+                        "results": {
+                                "0": "bf4788b1d0bb9e5c59c7e66bc38fb3c3",
+                                "1": "FALSEe4f7595847377657dc7d38ca47e43b01",
+                                "2": "65226e852b7a3409a3e2afa7b41a6e5c"
+                        }
+
+                },
+                {
+                        "name": "Library_Validation.json",
+                        "filepath": "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/Library_validation.json",
+                        "totaltime": 60,
+                        "results": {}
+                }
+
+
+        ]
+}
+
+
+	
+
+# -----------------------------------------------------
+# Run Quick test
+#[root@ansibler]
+
+    num_users=1
+    concurrent=False
+    test_level=quick
+
+    # Restart Zeppelin
+    time \
+        /deployments/hadoop-yarn/bin/restart-zeppelin.sh
+
+    time \
+        /deployments/hadoop-yarn/bin/run-tests.sh \
+            "${cloudname:?}" \
+            "${configname:?}" \
+            "${test_level:?}"  \
+	     ${concurrent:?}  \
+	     ${num_users:?}  \
+        | tee /tmp/run-tests-quick.log
+
+
+> Done
+
+TASK [Run benchmarker] **************************************************************************************************************************************************************************************
+changed: [localhost] => {"changed": true, "cmd": "python3 /tmp/run-test.py | tee /tmp/test-result.json", "delta": "0:02:11.675368", "end": "2022-03-04 13:52:53.840886", "rc": 0, "start": "2022-03-04 13:50:42.165518", "stderr": "", "stderr_lines": [], "stdout": "Test started [Single User]\nTest completed! (131.48 seconds)\n------------ Test Completion: [SLOW] ------------ Test Output: [INVALID] ------------\n[{'SetUp': {'totaltime': '46.97', 'status': 'SLOW', 'msg': '', 'valid': 'TRUE'}, 'Mean_proper_motions_over_the_sky': {'totaltime': '53.51', 'status': 'SUCCESS', 'msg': 'Expected/Actual output missmatch of cell #0! ', 'valid': 'FALSE'}, 'Source_counts_over_the_sky.json': {'totaltime': '21.32', 'status': 'SUCCESS', 'msg': 'Expected/Actual output missmatch of cell #1! ', 'valid': 'FALSE'}, 'Library_Validation.json': {'totaltime': '9.67', 'status': 'SUCCESS', 'msg': '', 'valid': 'TRUE'}}]", "stdout_lines": ["Test started [Single User]", "Test completed! (131.48 seconds)", "------------ Test Completion: [SLOW] ------------ Test Output: [INVALID] ------------", "[{'SetUp': {'totaltime': '46.97', 'status': 'SLOW', 'msg': '', 'valid': 'TRUE'}, 'Mean_proper_motions_over_the_sky': {'totaltime': '53.51', 'status': 'SUCCESS', 'msg': 'Expected/Actual output missmatch of cell #0! ', 'valid': 'FALSE'}, 'Source_counts_over_the_sky.json': {'totaltime': '21.32', 'status': 'SUCCESS', 'msg': 'Expected/Actual output missmatch of cell #1! ', 'valid': 'FALSE'}, 'Library_Validation.json': {'totaltime': '9.67', 'status': 'SUCCESS', 'msg': '', 'valid': 'TRUE'}}]"]}
+
+
+
+
+# Formatted results:
+
+------------ Test Completion: [SLOW] ------------ Test Output: [INVALID] ------------
+
+
+[{
+	'SetUp': {
+		'totaltime': '54.00',
+		'status': 'SLOW',
+		'msg': '',
+		'valid': 'TRUE'
+	},
+	'Mean_proper_motions_over_the_sky': {
+		'totaltime': '67.90',
+		'status': 'SLOW',
+		'msg': 'Expected/Actual output missmatch of cell #0! ',
+		'valid': 'FALSE'
+	},
+	'Source_counts_over_the_sky.json': {
+		'totaltime': '28.26',
+		'status': 'SLOW',
+		'msg': 'Expected/Actual output missmatch of cell #1! ',
+		'valid': 'FALSE'
+	},
+	'Library_Validation.json': {
+		'totaltime': '15.25',
+		'status': 'SUCCESS',
+		'msg': '',
+		'valid': 'TRUE'
+	}
+}]
+

--- a/notes/stv/20220316-test-benchmarker-01.txt
+++ b/notes/stv/20220316-test-benchmarker-01.txt
@@ -1,0 +1,315 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2022, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+
+    Target:
+
+        Run Test Deploy, and run benchmark
+        Validate that the tests fail correctly
+
+    Result:
+  
+        SUCCESS
+
+
+
+
+# -----------------------------------------------------
+# Fetch target branch
+#[user@desktop]
+
+    source "${HOME:?}/aglais.env"
+    pushd "${AGLAIS_CODE}"
+      	git checkout 'feature/upgrade-testing'
+
+    popd
+
+
+
+
+# -----------------------------------------------------
+# Create a container to work with.
+#[user@desktop]
+
+    source "${HOME:?}/aglais.env"
+
+    podman run \
+        --rm \
+        --tty \
+        --interactive \
+        --name ansibler323 \
+        --hostname ansibler \
+        --publish 3000:3000 \
+        --publish 8088:8088 \
+        --env "SSH_AUTH_SOCK=/mnt/ssh_auth_sock" \
+        --volume "${SSH_AUTH_SOCK}:/mnt/ssh_auth_sock:rw,z" \
+        --volume "${HOME:?}/clouds.yaml:/etc/openstack/clouds.yaml:ro,z" \
+        --volume "${AGLAIS_CODE:?}/deployments:/deployments:ro,z" \
+        atolmis/ansible-client:2021.08.25 \
+        bash
+
+
+
+# -----------------------------------------------------
+# Set the cloud and configuration.
+#[root@ansibler]
+
+    cloudname=iris-gaia-red
+
+    configname=zeppelin-27.45-spark-6.27.45
+
+
+
+# -----------------------------------------------------
+# Delete everything.
+#[root@ansibler]
+
+    time \
+        /deployments/openstack/bin/delete-all.sh \
+            "${cloudname:?}"
+
+        > Done
+
+
+
+# -----------------------------------------------------
+# Create everything, using the new config.
+#[root@ansibler]
+
+    time \
+        /deployments/hadoop-yarn/bin/create-all.sh \
+            "${cloudname:?}" \
+            "${configname:?}"   \
+        | tee /tmp/create-all.log
+
+
+        > Done
+
+
+
+# -----------------------------------------------------
+# Run Quick test
+#[root@ansibler]
+
+    num_users=1
+    concurrent=False
+    test_level=quick
+
+    time \
+        /deployments/hadoop-yarn/bin/run-tests.sh \
+            "${cloudname:?}" \
+            "${configname:?}" \
+            "${test_level:?}"  \
+	     ${concurrent:?}  \
+	     ${num_users:?}  \
+        | tee /tmp/run-tests-quick.log
+
+
+
+
+TASK [Run benchmarker] **************************************************************************************************************************************************************************************
+changed: [localhost] => {"changed": true, "cmd": "python3 /tmp/run-test.py | tee /tmp/test-result.json", "delta": "0:02:11.166341", "end": "2022-03-16 16:00:50.504366", "rc": 0, "start": "2022-03-16 15:58:39.338025", "stderr": "", "stderr_lines": [], "stdout": "Test started [Single User]\nTest completed! (131.03 seconds)\n------------ Test Result: [PASS] ------------\n[{'SetUp': {'result': 'PASS', 'outputs': {'valid': True}, 'time': {'result': 'SLOW', 'elapsed': '45.38', 'expected': '45.00', 'percent': '0.84', 'start': '2022-03-16T15:58:39.445596', 'finish': '2022-03-16T15:59:24.824208'}, 'logs': ''}, 'Mean_proper_motions_over_the_sky': {'result': 'PASS', 'outputs': {'valid': True}, 'time': {'result': 'SLOW', 'elapsed': '56.84', 'expected': '55.00', 'percent': '3.34', 'start': '2022-03-16T15:59:24.824360', 'finish': '2022-03-16T16:00:21.662642'}, 'logs': ''}, 'Source_counts_over_the_sky.json': {'result': 'PASS', 'outputs': {'valid': True}, 'time': {'result': 'FAST', 'elapsed': '21.92', 'expected': '22.00', 'percent': '-0.35', 'start': '2022-03-16T16:00:21.663684', 'finish': '2022-03-16T16:00:43.586986'}, 'logs': ''}, 'Library_Validation.json': {'result': 'PASS', 'outputs': {'valid': True}, 'time': {'result': 'FAST', 'elapsed': '6.89', 'expected': '60.00', 'percent': '-88.52', 'start': '2022-03-16T16:00:43.587353', 'finish': '2022-03-16T16:00:50.472850'}, 'logs': ''}}]", "stdout_lines": ["Test started [Single User]", "Test completed! (131.03 seconds)", "------------ Test Result: [PASS] ------------", "[{'SetUp': {'result': 'PASS', 'outputs': {'valid': True}, 'time': {'result': 'SLOW', 'elapsed': '45.38', 'expected': '45.00', 'percent': '0.84', 'start': '2022-03-16T15:58:39.445596', 'finish': '2022-03-16T15:59:24.824208'}, 'logs': ''}, 'Mean_proper_motions_over_the_sky': {'result': 'PASS', 'outputs': {'valid': True}, 'time': {'result': 'SLOW', 'elapsed': '56.84', 'expected': '55.00', 'percent': '3.34', 'start': '2022-03-16T15:59:24.824360', 'finish': '2022-03-16T16:00:21.662642'}, 'logs': ''}, 'Source_counts_over_the_sky.json': {'result': 'PASS', 'outputs': {'valid': True}, 'time': {'result': 'FAST', 'elapsed': '21.92', 'expected': '22.00', 'percent': '-0.35', 'start': '2022-03-16T16:00:21.663684', 'finish': '2022-03-16T16:00:43.586986'}, 'logs': ''}, 'Library_Validation.json': {'result': 'PASS', 'outputs': {'valid': True}, 'time': {'result': 'FAST', 'elapsed': '6.89', 'expected': '60.00', 'percent': '-88.52', 'start': '2022-03-16T16:00:43.587353', 'finish': '2022-03-16T16:00:50.472850'}, 'logs': ''}}]"]}
+
+
+
+
+# Results (Formatted): 
+
+------------ Test Result: [PASS] ------------
+
+[{
+	'SetUp': {
+		'result': 'PASS',
+		'outputs': {
+			'valid': True
+		},
+		'time': {
+			'result': 'SLOW',
+			'elapsed': '45.38',
+			'expected': '45.00',
+			'percent': '0.84',
+			'start': '2022-03-16T15:58:39.445596',
+			'finish': '2022-03-16T15:59:24.824208'
+		},
+		'logs': ''
+	},
+	'Mean_proper_motions_over_the_sky': {
+		'result': 'PASS',
+		'outputs': {
+			'valid': True
+		},
+		'time': {
+			'result': 'SLOW',
+			'elapsed': '56.84',
+			'expected': '55.00',
+			'percent': '3.34',
+			'start': '2022-03-16T15:59:24.824360',
+			'finish': '2022-03-16T16:00:21.662642'
+		},
+		'logs': ''
+	},
+	'Source_counts_over_the_sky.json': {
+		'result': 'PASS',
+		'outputs': {
+			'valid': True
+		},
+		'time': {
+			'result': 'FAST',
+			'elapsed': '21.92',
+			'expected': '22.00',
+			'percent': '-0.35',
+			'start': '2022-03-16T16:00:21.663684',
+			'finish': '2022-03-16T16:00:43.586986'
+		},
+		'logs': ''
+	},
+	'Library_Validation.json': {
+		'result': 'PASS',
+		'outputs': {
+			'valid': True
+		},
+		'time': {
+			'result': 'FAST',
+			'elapsed': '6.89',
+			'expected': '60.00',
+			'percent': '-88.52',
+			'start': '2022-03-16T16:00:43.587353',
+			'finish': '2022-03-16T16:00:50.472850'
+		},
+		'logs': ''
+	}
+}]
+
+
+# -----------------------------------------------------
+# Run Quick test
+# Check with modified checksum, that we get a correct fail status
+# (Modify quick.json notebook test config)
+#[user@local]
+# Add "AAA" to results of Mean_proper_motions_over_the_sky
+...
+
+                {
+                        "name": "Mean_proper_motions_over_the_sky",
+                        "filepath": "https://raw.githubusercontent.com/wfau/aglais-testing/main/notebooks/public_examples/Mean_proper_motions_over_the_sky.json",
+                        "totaltime": 55,
+                        "results": {
+                                "0": "AAA29b63ef48563f53e19460128434816e0",
+                                "1": "cde34ea3444ec37766aa2cfa8ab72b77",
+                                "2": "65226e852b7a3409a3e2afa7b41a6e5c",
+                                "3": "1fb0ffc6caff1d5097a55ca6329d7b79"
+                        }
+                },
+
+..
+
+#[root@ansibler]
+
+    num_users=1
+    concurrent=False
+    test_level=quick
+
+
+    # Restart Zeppelin
+    time \
+        /deployments/hadoop-yarn/bin/restart-zeppelin.sh
+
+    time \
+        /deployments/hadoop-yarn/bin/run-tests.sh \
+            "${cloudname:?}" \
+            "${configname:?}" \
+            "${test_level:?}"  \
+	     ${concurrent:?}  \
+	     ${num_users:?}  \
+        | tee /tmp/run-tests-quick.log
+
+
+TASK [Run benchmarker] **************************************************************************************************************************************************************************************
+changed: [localhost] => {"changed": true, "cmd": "python3 /tmp/run-test.py | tee /tmp/test-result.json", "delta": "0:02:04.005549", "end": "2022-03-16 16:12:47.070962", "rc": 0, "start": "2022-03-16 16:10:43.065413", "stderr": "", "stderr_lines": [], "stdout": "Test started [Single User]\nTest completed! (123.87 seconds)\n------------ Test Result: [FAIL] ------------\n[{'SetUp': {'result': 'PASS', 'outputs': {'valid': True}, 'time': {'result': 'FAST', 'elapsed': '42.15', 'expected': '45.00', 'percent': '-6.34', 'start': '2022-03-16T16:10:43.178029', 'finish': '2022-03-16T16:11:25.326711'}, 'logs': ''}, 'Mean_proper_motions_over_the_sky': {'result': 'FAIL', 'outputs': {'valid': False}, 'time': {'result': 'FAST', 'elapsed': '49.44', 'expected': '55.00', 'percent': '-10.11', 'start': '2022-03-16T16:11:25.326927', 'finish': '2022-03-16T16:12:14.768406'}, 'logs': 'Expected/Actual output missmatch of cell #0! '}, 'Source_counts_over_the_sky.json': {'result': 'PASS', 'outputs': {'valid': True}, 'time': {'result': 'SLOW', 'elapsed': '24.81', 'expected': '22.00', 'percent': '12.77', 'start': '2022-03-16T16:12:14.769540', 'finish': '2022-03-16T16:12:39.579428'}, 'logs': ''}, 'Library_Validation.json': {'result': 'PASS', 'outputs': {'valid': True}, 'time': {'result': 'FAST', 'elapsed': '7.47', 'expected': '60.00', 'percent': '-87.55', 'start': '2022-03-16T16:12:39.579718', 'finish': '2022-03-16T16:12:47.049799'}, 'logs': ''}}]", "stdout_lines": ["Test started [Single User]", "Test completed! (123.87 seconds)", "------------ Test Result: [FAIL] ------------", "[{'SetUp': {'result': 'PASS', 'outputs': {'valid': True}, 'time': {'result': 'FAST', 'elapsed': '42.15', 'expected': '45.00', 'percent': '-6.34', 'start': '2022-03-16T16:10:43.178029', 'finish': '2022-03-16T16:11:25.326711'}, 'logs': ''}, 'Mean_proper_motions_over_the_sky': {'result': 'FAIL', 'outputs': {'valid': False}, 'time': {'result': 'FAST', 'elapsed': '49.44', 'expected': '55.00', 'percent': '-10.11', 'start': '2022-03-16T16:11:25.326927', 'finish': '2022-03-16T16:12:14.768406'}, 'logs': 'Expected/Actual output missmatch of cell #0! '}, 'Source_counts_over_the_sky.json': {'result': 'PASS', 'outputs': {'valid': True}, 'time': {'result': 'SLOW', 'elapsed': '24.81', 'expected': '22.00', 'percent': '12.77', 'start': '2022-03-16T16:12:14.769540', 'finish': '2022-03-16T16:12:39.579428'}, 'logs': ''}, 'Library_Validation.json': {'result': 'PASS', 'outputs': {'valid': True}, 'time': {'result': 'FAST', 'elapsed': '7.47', 'expected': '60.00', 'percent': '-87.55', 'start': '2022-03-16T16:12:39.579718', 'finish': '2022-03-16T16:12:47.049799'}, 'logs': ''}}]"]}
+
+
+
+# Results (Formatted): 	
+
+------------ Test Result: [FAIL] ------------
+
+[{
+	'SetUp': {
+		'result': 'PASS',
+		'outputs': {
+			'valid': True
+		},
+		'time': {
+			'result': 'FAST',
+			'elapsed': '42.15',
+			'expected': '45.00',
+			'percent': '-6.34',
+			'start': '2022-03-16T16:10:43.178029',
+			'finish': '2022-03-16T16:11:25.326711'
+		},
+		'logs': ''
+	},
+	'Mean_proper_motions_over_the_sky': {
+		'result': 'FAIL',
+		'outputs': {
+			'valid': False
+		},
+		'time': {
+			'result': 'FAST',
+			'elapsed': '49.44',
+			'expected': '55.00',
+			'percent': '-10.11',
+			'start': '2022-03-16T16:11:25.326927',
+			'finish': '2022-03-16T16:12:14.768406'
+		},
+		'logs': 'Expected/Actual output missmatch of cell #0! '
+	},
+	'Source_counts_over_the_sky.json': {
+		'result': 'PASS',
+		'outputs': {
+			'valid': True
+		},
+		'time': {
+			'result': 'SLOW',
+			'elapsed': '24.81',
+			'expected': '22.00',
+			'percent': '12.77',
+			'start': '2022-03-16T16:12:14.769540',
+			'finish': '2022-03-16T16:12:39.579428'
+		},
+		'logs': ''
+	},
+	'Library_Validation.json': {
+		'result': 'PASS',
+		'outputs': {
+			'valid': True
+		},
+		'time': {
+			'result': 'FAST',
+			'elapsed': '7.47',
+			'expected': '60.00',
+			'percent': '-87.55',
+			'start': '2022-03-16T16:12:39.579718',
+			'finish': '2022-03-16T16:12:47.049799'
+		},
+		'logs': ''
+	}
+}]


### PR DESCRIPTION
Modified test configurations to include md5 checksums for cell outputs. Does not include all cells. as some have output that changes per run (For example including current timestamp).
Upgrade version of aglais-testing that we use to 0.1.8 (which checks the output of the cell with the expected value)
Added notes on test deploy