### PR TITLE
Create and enable a MySQL Shiro database for storing and authenticating Zeppelin Users

### DIFF
--- a/deployments/common/zeppelin/sql/auth-test.sql
+++ b/deployments/common/zeppelin/sql/auth-test.sql
@@ -1,0 +1,35 @@
+USE zeppelin;
+CREATE TABLE users (username TEXT, password TEXT, password_salt TEXT);
+CREATE TABLE user_roles (username TEXT, role_name TEXT);
+CREATE TABLE user_permissions (username TEXT, permission TEXT);
+GRANT ALL PRIVILEGES ON zeppelin.users TO 'zeppelin'@'localhost';
+GRANT ALL PRIVILEGES ON zeppelin.user_roles TO 'zeppelin'@'localhost';
+GRANT ALL PRIVILEGES ON zeppelin.user_permissions TO 'zeppelin'@'localhost';
+
+# Create test users
+
+INSERT INTO users (username, password) VALUES ('gaiauser1', '$shiro1..........f5giMWb5axaB+8cNE5B1oe4w58=');
+INSERT INTO users (username, password) VALUES ('gaiauser2', '$shiro1$SH-.....sRoJS912hLLnMsjGKHA=');
+INSERT INTO users (username, password) VALUES ('gaiauser3', '$shiro1$SHA........gQLtfF+JJ4Nvoztdv850=');
+INSERT INTO users (username, password) VALUES ('gaiauser4', '$shiro1$SHA..........lda86sTHvKypv0=');
+INSERT INTO users (username, password) VALUES ('gaiauser5', '$shiro1$SHA-.........vZfL3igfFTjzk9AjlC1UJdY=');
+INSERT INTO users (username, password) VALUES ('gaiauser6', '$shiro1$SHA-........Rzlyr5eeuBEkPyyLSWo=');
+INSERT INTO users (username, password) VALUES ('gaiauser7', '$shiro1$SHA-..........9WXdKLPXQeWC17iyOmkK8PkLDYHMvHQ=');
+INSERT INTO users (username, password) VALUES ('gaiauser8', '$shiro1$SH............673LYs6EqSEH1LSec95c=');
+INSERT INTO users (username, password) VALUES ('gaiauser9', '$shiro1$SHA-z............jozPuicSp5DNw45OnvdUxSU10kb2k=');
+INSERT INTO users (username, password) VALUES ('gaiauser10', '$shiro1$SH............ZObnftBrFs+WLqI/oS2uvb2/vPJDU=');
+
+# Create roles
+
+INSERT INTO user_roles (username, role_name) VALUES ('gaiauser1', 'user');
+INSERT INTO user_roles (username, role_name) VALUES ('gaiauser2', 'user');
+INSERT INTO user_roles (username, role_name) VALUES ('gaiauser3', 'user');
+INSERT INTO user_roles (username, role_name) VALUES ('gaiauser4', 'user');
+INSERT INTO user_roles (username, role_name) VALUES ('gaiauser5', 'user');
+INSERT INTO user_roles (username, role_name) VALUES ('gaiauser6', 'user');
+INSERT INTO user_roles (username, role_name) VALUES ('gaiauser7', 'user');
+INSERT INTO user_roles (username, role_name) VALUES ('gaiauser8', 'user');
+INSERT INTO user_roles (username, role_name) VALUES ('gaiauser9', 'user');
+INSERT INTO user_roles (username, role_name) VALUES ('gaiauser10', 'user');
+
+

--- a/deployments/common/zeppelin/sql/auth.sql
+++ b/deployments/common/zeppelin/sql/auth.sql
@@ -1,0 +1,27 @@
+USE zeppelin;
+CREATE TABLE users (username TEXT, password TEXT, password_salt TEXT);
+CREATE TABLE user_roles (username TEXT, role_name TEXT);
+CREATE TABLE user_permissions (username TEXT, permission TEXT);
+GRANT ALL PRIVILEGES ON zeppelin.users TO 'zeppelin'@'localhost';
+GRANT ALL PRIVILEGES ON zeppelin.user_roles TO 'zeppelin'@'localhost';
+GRANT ALL PRIVILEGES ON zeppelin.user_permissions TO 'zeppelin'@'localhost';
+
+
+INSERT INTO users (username, password) VALUES ('gaiauser', '$shiro1$SHA-256$500...........R0GxWVAH028tjMyIkbKmMDW2E0=');
+INSERT INTO users (username, password) VALUES ('dcr', '$shiro1$SHA-256$500000...........bp5aQVQtw6kmVMUlENoGkrBPjCDqWOs=');
+INSERT INTO users (username, password) VALUES ('nch', '$shiro1$SHA-256$500000$MPs..............5lBwoKj7LtnBMUZJp4XmCyBv9yvMZrM=');
+INSERT INTO users (username, password) VALUES ('zrq', '$shiro1$SHA-256$50000...............Pm6tS4XfOETCwEwI8Ri5FE8GfM2uBRQ=');
+INSERT INTO users (username, password) VALUES ('stv', '$shiro1$SHA-25.....................sAkP3jjvbeq1KHgieb00pIizAM=');
+INSERT INTO users (username, password) VALUES ('admin', '$shiro1$SHA-256$50000.................p+LFeSFqvBNMKVpYMVMCc+cE8/rrTQI=');
+INSERT INTO users (username, password) VALUES ('yrvafhom', '$shiro1$SHA-256$500000$b/..............C9diAs6AUdv/29qjtsSLqmWUQ=');
+
+# Create roles
+
+INSERT INTO user_roles (username, role_name) VALUES ('admin', 'admin');
+INSERT INTO user_roles (username, role_name) VALUES ('dcr', 'user');
+INSERT INTO user_roles (username, role_name) VALUES ('nch', 'user');
+INSERT INTO user_roles (username, role_name) VALUES ('zrq', 'user');
+INSERT INTO user_roles (username, role_name) VALUES ('stv', 'user');
+INSERT INTO user_roles (username, role_name) VALUES ('yrvafhom', 'user');
+
+

--- a/deployments/common/zeppelin/sql/create.sql
+++ b/deployments/common/zeppelin/sql/create.sql
@@ -1,0 +1,8 @@
+USE zeppelin;
+CREATE TABLE users (username TEXT, password TEXT, password_salt TEXT);
+CREATE TABLE user_roles (username TEXT, role_name TEXT);
+CREATE TABLE user_permissions (username TEXT, permission TEXT);
+GRANT ALL PRIVILEGES ON zeppelin.users TO 'zeppelin'@'localhost';
+GRANT ALL PRIVILEGES ON zeppelin.user_roles TO 'zeppelin'@'localhost';
+GRANT ALL PRIVILEGES ON zeppelin.user_permissions TO 'zeppelin'@'localhost';
+

--- a/deployments/hadoop-yarn/ansible/27-install-zeppelin.yml
+++ b/deployments/hadoop-yarn/ansible/27-install-zeppelin.yml
@@ -274,9 +274,3 @@
         group: "{{zepuser}}"
         mode: 0775
 
-
-    - name: "Get MySQL Connector jar"
-      get_url:
-        url: https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.28/mysql-connector-java-8.0.28.jar
-        dest: "{{zephome}}/lib/mysql-connector-java-8.0.28.jar"
-

--- a/deployments/hadoop-yarn/ansible/27-install-zeppelin.yml
+++ b/deployments/hadoop-yarn/ansible/27-install-zeppelin.yml
@@ -217,45 +217,6 @@
 
             </configuration>
 
-    zeppelinshiro: |
-            [main]
-            ds = com.mysql.cj.jdbc.MysqlDataSource
-            ds.serverName = 128.232.222.125
-            ds.databaseName = zeppelin
-            ds.user = zeppelin
-            ds.password = pass
-            
-            jdbcRealm = org.apache.shiro.realm.jdbc.JdbcRealm
-            ps = org.apache.shiro.authc.credential.DefaultPasswordService
-            pm = org.apache.shiro.authc.credential.PasswordMatcher
-            pm.passwordService = $ps
-            
-            jdbcRealm.dataSource = $ds
-            jdbcRealm.credentialsMatcher = $pm
-            shiro.loginUrl = /api/login
-            
-            sessionManager = org.apache.shiro.web.session.mgt.DefaultWebSessionManager
-            cookie = org.apache.shiro.web.servlet.SimpleCookie
-            cookie.name = JSESSIONID
-            cookie.httpOnly = true
-            sessionManager.sessionIdCookie = $cookie
-            securityManager.sessionManager = $sessionManager
-            securityManager.sessionManager.globalSessionTimeout = 86400000
-            
-            
-            [urls]
-            /** = authc
-            /api/version = anon
-            /api/interpreter/setting/restart/** = authc
-            /api/interpreter/** = authc, roles[admin]
-            /api/configurations/** = authc, roles[admin]
-            /api/credential/** = authc, roles[admin]
-            
-            
-            [roles]
-            user = *
-            admin = *
-
   tasks:
     - name: "Install Zeppelin"
       unarchive:
@@ -301,16 +262,6 @@
         mode:  'u=rw,g=r,o=r'
         dest:  "{{zephome}}/conf/zeppelin-site.xml"
         content: "{{ zeppelinconfig }}"
-      tags:
-        - always
-
-    - name: "Create a Zeppelin Shiro Configuration"
-      copy:
-        owner: "{{zepuser}}"
-        group: "{{zepuser}}"
-        mode:  'u=rw,g=r,o=r'
-        dest:  "{{zephome}}/conf/shiro.ini"
-        content: "{{ zeppelinshiro }}"
       tags:
         - always
 

--- a/deployments/hadoop-yarn/ansible/27-install-zeppelin.yml
+++ b/deployments/hadoop-yarn/ansible/27-install-zeppelin.yml
@@ -218,41 +218,43 @@
             </configuration>
 
     zeppelinshiro: |
-            [users]
-            # List of users with their password allowed to access Zeppelin.
-            admin = pass, admin
-            gaiauser = gaiapass, role1
-            gaiauser1 = gaiapass1, role1
-            gaiauser2 = gaiapass2, role1
-            gaiauser3 = gaiapass3, role1
-
             [main]
-
+            ds = com.mysql.cj.jdbc.MysqlDataSource
+            ds.serverName = 128.232.222.125
+            ds.databaseName = zeppelin
+            ds.user = zeppelin
+            ds.password = pass
+            
+            jdbcRealm = org.apache.shiro.realm.jdbc.JdbcRealm
+            ps = org.apache.shiro.authc.credential.DefaultPasswordService
+            pm = org.apache.shiro.authc.credential.PasswordMatcher
+            pm.passwordService = $ps
+            
+            jdbcRealm.dataSource = $ds
+            jdbcRealm.credentialsMatcher = $pm
+            shiro.loginUrl = /api/login
+            
             sessionManager = org.apache.shiro.web.session.mgt.DefaultWebSessionManager
             cookie = org.apache.shiro.web.servlet.SimpleCookie
             cookie.name = JSESSIONID
             cookie.httpOnly = true
             sessionManager.sessionIdCookie = $cookie
-
             securityManager.sessionManager = $sessionManager
             securityManager.sessionManager.globalSessionTimeout = 86400000
-            shiro.loginUrl = /api/login
-
-            [roles]
-            role1 = *
-            role2 = *
-            role3 = *
-            admin = *
-
+            
+            
             [urls]
+            /** = authc
             /api/version = anon
-
             /api/interpreter/setting/restart/** = authc
             /api/interpreter/** = authc, roles[admin]
             /api/configurations/** = authc, roles[admin]
             /api/credential/** = authc, roles[admin]
-
-            /** = authc
+            
+            
+            [roles]
+            user = *
+            admin = *
 
   tasks:
     - name: "Install Zeppelin"
@@ -320,4 +322,10 @@
         owner: "{{zepuser}}"
         group: "{{zepuser}}"
         mode: 0775
+
+
+    - name: "Get MySQL Connector jar"
+      get_url:
+        url: https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.28/mysql-connector-java-8.0.28.jar
+        dest: "{{zephome}}/lib/mysql-connector-java-8.0.28.jar"
 

--- a/deployments/hadoop-yarn/ansible/38-install-user-db.yml
+++ b/deployments/hadoop-yarn/ansible/38-install-user-db.yml
@@ -138,12 +138,6 @@
        priv: "zeppelin.*:ALL"
        state: present
 
-   - name: "Copy Auth SQL file to Zeppelin"
-     copy: src="{{ playbook_dir | dirname | dirname }}/common/zeppelin/sql/{{ users_import_file }}" dest=/tmp
-
-   - name: "Import Zeppelin user data"
-     mysql_db: name=zeppelin state=import target=/tmp/{{ users_import_file }}
-
    - name: "Create a Zeppelin Shiro Configuration"
      copy:
        owner: "{{zepuser}}"

--- a/deployments/hadoop-yarn/ansible/38-install-user-db.yml
+++ b/deployments/hadoop-yarn/ansible/38-install-user-db.yml
@@ -1,0 +1,156 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2022, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+#
+
+---
+- name: "Install MySQL Database for Zeppelin/Shiro"
+  hosts: zeppelin
+  become: yes
+  become_user: root
+  gather_facts: false
+  vars_files:
+    - config/ansible.yml
+    - config/hadoop.yml
+    - /tmp/ansible-vars.yml
+    - config/zeppelin.yml
+  vars:
+    zeppelinshiro: |
+            [main]
+            ds = com.mysql.cj.jdbc.MysqlDataSource
+            ds.serverName = localhost
+            ds.databaseName = zeppelin
+            ds.user = zeppelin
+            ds.password = {{ mysql_zeppelin_password }}
+
+            jdbcRealm = org.apache.shiro.realm.jdbc.JdbcRealm
+            ps = org.apache.shiro.authc.credential.DefaultPasswordService
+            pm = org.apache.shiro.authc.credential.PasswordMatcher
+            pm.passwordService = $ps
+
+            jdbcRealm.dataSource = $ds
+            jdbcRealm.credentialsMatcher = $pm
+            shiro.loginUrl = /api/login
+
+            sessionManager = org.apache.shiro.web.session.mgt.DefaultWebSessionManager
+            cookie = org.apache.shiro.web.servlet.SimpleCookie
+            cookie.name = JSESSIONID
+            cookie.httpOnly = true
+            sessionManager.sessionIdCookie = $cookie
+            securityManager.sessionManager = $sessionManager
+            securityManager.sessionManager.globalSessionTimeout = 86400000
+
+
+            [urls]
+            /** = authc
+            /api/version = anon
+            /api/interpreter/setting/restart/** = authc
+            /api/interpreter/** = authc, roles[admin]
+            /api/configurations/** = authc, roles[admin]
+            /api/credential/** = authc, roles[admin]
+
+            [roles]
+            user = *
+            admin = *
+
+  tasks:
+
+   - set_fact:
+       mysql_root_password: "{{ lookup('password','/dev/null chars=ascii_letters,digits,hexdigits length=20') }}!"
+       mysql_zeppelin_password: "{{ lookup('password','/dev/null chars=ascii_letters,digits,hexdigits length=20') }}!"
+
+   - name: "Enable MySQL Community release repo"
+     yum:
+       disable_gpg_check: True
+       name: https://repo.mysql.com//mysql80-community-release-fc31-1.noarch.rpm
+       state: present
+
+   - name: "Install MySQL Server"
+     yum: name=mysql-server state=installed
+
+   - name: "Install MySQL-devel"
+     yum: name=mysql-devel state=installed
+
+   - name: "Make sure pymysql is present"
+     pip:
+       name: pymysql
+       state: present
+
+   - name: "Start the MySQL service"
+     service: 
+       name: mysqld 
+       state: started
+       enabled: yes
+
+   - name: "Find temporary password"
+     shell: "echo `grep 'temporary.*root@localhost' /var/log/mysqld.log | sed
+'s/.*root@localhost: //'`"
+     register: mysql_root_password_temp
+     tags: register
+
+   - name: "Update expired root user password"
+     shell: 'mysql -e "ALTER USER ''root''@''localhost'' IDENTIFIED WITH mysql_native_password BY ''{{ mysql_root_password }}''" --connect-expired-password -uroot -p"{{ mysql_root_password_temp.stdout }}"'
+
+   - name: "Create MySQL config"
+     become: true
+     blockinfile:
+       dest:  '/root/.my.cnf'
+       state: present
+       owner: 'root'
+       group: 'root'
+       mode:  'u=rw,g=r,o=r'
+       create: true
+       insertafter: 'EOF'
+       block: |
+         [client]
+         user=root
+         password={{ mysql_root_password }}
+         [client2]
+         user=root
+         password={{ mysql_zeppelin_password }}
+         [mysqld]
+         bind-address            = 0.0.0.0
+
+   - name: "Create Zeppelin database"
+     mysql_db: name=zeppelin state=present login_user=root login_password={{ mysql_root_password }}
+
+   - name: "Create MySQL Zeppelin user with appropriate privileges"
+     mysql_user:	
+       name: zeppelin
+       password: '{{ mysql_zeppelin_password }}'
+       priv: "zeppelin.*:ALL"
+       state: present
+
+   - name: "Copy Auth SQL file to Zeppelin"
+     copy: src="{{ playbook_dir | dirname | dirname }}/common/zeppelin/sql/{{ users_import_file }}" dest=/tmp
+
+   - name: "Import Zeppelin user data"
+     mysql_db: name=zeppelin state=import target=/tmp/{{ users_import_file }}
+
+   - name: "Create a Zeppelin Shiro Configuration"
+     copy:
+       owner: "{{zepuser}}"
+       group: "{{zepuser}}"
+       mode:  'u=rw,g=r,o=r'
+       dest:  "{{zephome}}/conf/shiro.ini"
+       content: "{{ zeppelinshiro }}"
+     tags:
+       - always
+

--- a/deployments/hadoop-yarn/ansible/38-install-user-db.yml
+++ b/deployments/hadoop-yarn/ansible/38-install-user-db.yml
@@ -23,8 +23,7 @@
 ---
 - name: "Install MySQL Database for Zeppelin/Shiro"
   hosts: zeppelin
-  become: yes
-  become_user: root
+  become: true
   gather_facts: false
   vars_files:
     - config/ansible.yml
@@ -82,6 +81,11 @@
        name: https://repo.mysql.com//mysql80-community-release-fc31-1.noarch.rpm
        state: present
 
+   - name: "Get MySQL Connector jar"
+     get_url:
+       url: https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.28/mysql-connector-java-8.0.28.jar
+       dest: "{{zephome}}/lib/mysql-connector-java-8.0.28.jar"
+
    - name: "Install MySQL Server"
      yum: name=mysql-server state=installed
 
@@ -93,11 +97,15 @@
        name: pymysql
        state: present
 
+   - name: "reload systemd"
+     command: systemctl daemon-reload
+
    - name: "Start the MySQL service"
      service: 
-       name: mysqld 
+       name: mysqld
        state: started
        enabled: yes
+       daemon_reload: yes
 
    - name: "Find temporary password"
      shell: "echo `grep 'temporary.*root@localhost' /var/log/mysqld.log | sed
@@ -147,4 +155,11 @@
        content: "{{ zeppelinshiro }}"
      tags:
        - always
+
+   - name: "Copy Create SQL file to Zeppelin"
+     copy: src="{{ playbook_dir | dirname | dirname }}/common/zeppelin/sql/create.sql" dest=/tmp
+
+   - name: "Create User SQL database"
+     mysql_db: name=zeppelin state=import target=/tmp/create.sql
+
 

--- a/deployments/hadoop-yarn/ansible/39-import-users.yml
+++ b/deployments/hadoop-yarn/ansible/39-import-users.yml
@@ -1,0 +1,42 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2022, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+#
+
+---
+- name: "Import Users to Shiro Database"
+  hosts: zeppelin
+  become: yes
+  become_user: root
+  gather_facts: false
+  vars_files:
+    - config/ansible.yml
+    - config/hadoop.yml
+    - /tmp/ansible-vars.yml
+    - config/zeppelin.yml
+  vars:
+  tasks:
+
+   - name: "Copy Auth SQL file to Zeppelin"
+     copy: src="{{ playbook_dir | dirname | dirname }}/common/zeppelin/sql/{{ users_import_file }}" dest=/tmp
+
+   - name: "Import Zeppelin user data"
+     mysql_db: name=zeppelin state=import target=/tmp/{{ users_import_file }}
+

--- a/deployments/hadoop-yarn/ansible/40-create-shiro-file.yml
+++ b/deployments/hadoop-yarn/ansible/40-create-shiro-file.yml
@@ -1,0 +1,79 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2020, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+
+- name: "Install Zeppelin"
+  hosts: zeppelin
+  gather_facts: yes
+  vars_files:
+    - config/ansible.yml
+    - config/hadoop.yml
+    - /tmp/ansible-vars.yml
+    - config/zeppelin.yml
+  vars:
+    zeppelinshiro: |
+            [users]
+            # List of users with their password allowed to access Zeppelin.
+            admin = pass, admin
+            gaiauser = gaiapass, role1
+            gaiauser2 = gaiapass2, role1
+            gaiauser3 = gaiapass3, role1
+
+            [main]
+
+            sessionManager = org.apache.shiro.web.session.mgt.DefaultWebSessionManager
+            cookie = org.apache.shiro.web.servlet.SimpleCookie
+            cookie.name = JSESSIONID
+            cookie.httpOnly = true
+            sessionManager.sessionIdCookie = $cookie
+
+            securityManager.sessionManager = $sessionManager
+            securityManager.sessionManager.globalSessionTimeout = 86400000
+            shiro.loginUrl = /api/login
+
+            [roles]
+            role1 = *
+            role2 = *
+            role3 = *
+            admin = *
+
+            [urls]
+            /api/version = anon
+
+            /api/interpreter/setting/restart/** = authc
+            /api/interpreter/** = authc, roles[admin]
+            /api/configurations/** = authc, roles[admin]
+            /api/credential/** = authc, roles[admin]
+
+            /** = authc
+
+  tasks:
+
+    - name: "Create a Zeppelin Shiro Configuration"
+      copy:
+        owner: "{{zepuser}}"
+        group: "{{zepuser}}"
+        mode:  'u=rw,g=r,o=r'
+        dest:  "{{zephome}}/conf/shiro.ini"
+        content: "{{ zeppelinshiro }}"
+      tags:
+        - always
+

--- a/deployments/hadoop-yarn/bin/create-all.sh
+++ b/deployments/hadoop-yarn/bin/create-all.sh
@@ -140,29 +140,6 @@
 
     popd
 
-# Create the Zeppelin Shiro Database.
-
-    echo ""
-    echo "---- ----"
-    echo "Creating Zeppelin Shiro database"
-
-    pushd "${treetop:?}/hadoop-yarn/ansible"
-
-        if [ "${deploytype}" == "test" ]
-        then
-            ansible-playbook \
-                --inventory "${inventory:?}" \
-                --extra-vars "users_import_file=auth-test.sql" \
-                "38-install-user-db.yml"
-        else
-            ansible-playbook \
-                --inventory "${inventory:?}" \
-                --extra-vars "users_import_file=auth.sql" \
-                "38-install-user-db.yml"
-        fi
-
-    popd
-
 
 
 # -----------------------------------------------------

--- a/deployments/hadoop-yarn/bin/create-all.sh
+++ b/deployments/hadoop-yarn/bin/create-all.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+	#!/bin/sh
 #
 # <meta:header>
 #   <meta:licence>
@@ -45,8 +45,6 @@
     deployconf="${2:-medium-04}"
     deployname="${cloudname:?}-$(date '+%Y%m%d')"
     deploydate=$(date '+%Y%m%dT%H%M%S')
-
-    deploytype="${3:-prod}"
 
     configyml='/tmp/aglais-config.yml'
     statusyml='/tmp/aglais-status.yml'

--- a/deployments/hadoop-yarn/bin/create-all.sh
+++ b/deployments/hadoop-yarn/bin/create-all.sh
@@ -46,6 +46,8 @@
     deployname="${cloudname:?}-$(date '+%Y%m%d')"
     deploydate=$(date '+%Y%m%dT%H%M%S')
 
+    deploytype="${3:-prod}"
+
     configyml='/tmp/aglais-config.yml'
     statusyml='/tmp/aglais-status.yml'
     touch "${statusyml:?}"
@@ -137,6 +139,30 @@
             "create-all.yml"
 
     popd
+
+# Create the Zeppelin Shiro Database.
+
+    echo ""
+    echo "---- ----"
+    echo "Creating Zeppelin Shiro database"
+
+    pushd "${treetop:?}/hadoop-yarn/ansible"
+
+        if [ "${deploytype}" == "test" ]
+        then
+            ansible-playbook \
+                --inventory "${inventory:?}" \
+                --extra-vars "users_import_file=auth-test.sql" \
+                "38-install-user-db.yml"
+        else
+            ansible-playbook \
+                --inventory "${inventory:?}" \
+                --extra-vars "users_import_file=auth.sql" \
+                "38-install-user-db.yml"
+        fi
+
+    popd
+
 
 
 # -----------------------------------------------------

--- a/deployments/hadoop-yarn/bin/create-users.sh
+++ b/deployments/hadoop-yarn/bin/create-users.sh
@@ -39,13 +39,13 @@
     deployconf="${2:?}"
 
     inventory="${treetop:?}/hadoop-yarn/ansible/config/${deployconf:?}.yml"
-    deploytype="${3:-prod}"
+    authtype="${3:-prod}"
 
 
 
     echo "---- ---- ----"
     echo "Deploy conf [${deployconf}]"
-    echo "Deploy Type [${deploytype}]"
+    echo "Auth Type [${authtype}]"
     echo "---- ---- ----"
 
 
@@ -57,9 +57,12 @@
 
     pushd "${treetop:?}/hadoop-yarn/ansible"
 
+        if [ "${authtype}" != "prod" ]
+        then
             ansible-playbook \
                 --inventory "${inventory:?}" \
                 "38-install-user-db.yml"
+        fi
     popd
 
 
@@ -69,18 +72,24 @@
     pushd "${treetop:?}/hadoop-yarn/ansible"
 
 
-        if [ "${deploytype}" == "test" ]
+        if [ "${authtype}" == "test" ]
         then
             ansible-playbook \
                 --inventory "${inventory:?}" \
                 --extra-vars "users_import_file=auth-test.sql" \
                 "39-import-users.yml"
-        else
+        elif [ "${authtype}" == "jdbc" ]
+        then
             ansible-playbook \
                 --inventory "${inventory:?}" \
                 --extra-vars "users_import_file=auth.sql" \
                 "39-import-users.yml"
+        else
+            ansible-playbook \
+                --inventory "${inventory:?}" \
+                "40-create-shiro-file.yml"
         fi
+
 
     popd
 

--- a/deployments/hadoop-yarn/bin/create-users.sh
+++ b/deployments/hadoop-yarn/bin/create-users.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2022, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+#
+
+    set -eu
+    set -o pipefail
+
+    binfile="$(basename ${0})"
+    binpath="$(dirname $(readlink -f ${0}))"
+    treetop="$(dirname $(dirname ${binpath}))"
+
+    echo ""
+    echo "---- ---- ----"
+    echo "File [${binfile}]"
+    echo "Path [${binpath}]"
+    echo "Tree [${treetop}]"
+
+    cloudbase='arcus'
+    cloudname=${1:?}
+    deployconf="${2:?}"
+
+    inventory="${treetop:?}/hadoop-yarn/ansible/config/${deployconf:?}.yml"
+    deploytype="${3:-prod}"
+
+
+
+    echo "---- ---- ----"
+    echo "Deploy conf [${deployconf}]"
+    echo "Deploy Type [${deploytype}]"
+    echo "---- ---- ----"
+
+
+    # Create the Zeppelin Shiro Database.
+
+    echo ""
+    echo "---- ----"
+    echo "Creating Zeppelin Shiro database"
+
+    pushd "${treetop:?}/hadoop-yarn/ansible"
+
+            ansible-playbook \
+                --inventory "${inventory:?}" \
+                "38-install-user-db.yml"
+    popd
+
+
+
+    # Import users
+
+    pushd "${treetop:?}/hadoop-yarn/ansible"
+
+
+        if [ "${deploytype}" == "test" ]
+        then
+            ansible-playbook \
+                --inventory "${inventory:?}" \
+                --extra-vars "users_import_file=auth-test.sql" \
+                "39-import-users.yml"
+        else
+            ansible-playbook \
+                --inventory "${inventory:?}" \
+                --extra-vars "users_import_file=auth.sql" \
+                "39-import-users.yml"
+        fi
+
+    popd
+
+
+# -----------------------------------------------------
+# Restart the Zeppelin service.
+
+    "${treetop:?}/hadoop-yarn/bin/restart-zeppelin.sh"
+
+

--- a/notes/stv/20220405-mysql-shiro-experiment-01.txt
+++ b/notes/stv/20220405-mysql-shiro-experiment-01.txt
@@ -1,0 +1,163 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2022, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+
+Online Documentation:
+
+From dmr:
+https://gist.github.com/dominicfarr/9637357
+https://shiro.apache.org/static/1.3.2/apidocs/org/apache/shiro/realm/jdbc/JdbcRealm.html
+https://stackoverflow.com/questions/17440525/using-jdbcrealm-to-authenticate-user-with-shiro
+
+
+Other:
+https://gist.github.com/adamjshook/6c42b03fdb09b60cd519174d0aec1af5
+
+
+
+# ------------------------------------
+# Install MySQL
+# fedora@zeppelin
+
+sudo dnf -y install https://repo.mysql.com//mysql80-community-release-fc31-1.noarch.rpm
+sudo dnf install mysql-community-server
+sudo systemctl start mysqld.service
+sudo systemctl enable mysqld.service
+sudo grep 'A temporary password' /var/log/mysqld.log |tail -1
+sudo mysql_secure_installation
+
+
+# -------------------------------------------------
+# Login to MySQL, create database, user, tables
+# fedora@zeppelin
+
+mysql -u root -p
+
+# mysql> CREATE DATABASE zeppelin;
+# mysql> USE zeppelin;
+# mysql> CREATE USER 'zeppelin'@'localhost' IDENTIFIED BY 'zeppelin';
+# mysql> CREATE TABLE users (username TEXT, password TEXT, password_salt TEXT);
+# mysql> CREATE TABLE user_roles (username TEXT, role_name TEXT);
+# mysql> CREATE TABLE user_permissions (username TEXT, permission TEXT);
+# mysql> GRANT ALL PRIVILEGES ON zeppelin.users TO 'zeppelin'@'localhost';
+# mysql> GRANT ALL PRIVILEGES ON zeppelin.user_roles TO 'zeppelin'@'localhost';
+# mysql> GRANT ALL PRIVILEGES ON zeppelin.user_permissions TO 'zeppelin'@'localhost';
+
+
+
+# -------------------------------------------
+# Create new shiro configuration file
+# replace root/pass with zeppelin username and password
+# fedora@zeppelin
+
+nano conf/shiro.ini                                                                                              
+..
+
+[main]
+ds = com.mysql.cj.jdbc.MysqlDataSource
+ds.serverName = localhost
+ds.databaseName = zeppelin
+ds.user = root
+ds.password = pass
+
+jdbcRealm = org.apache.shiro.realm.jdbc.JdbcRealm
+ps = org.apache.shiro.authc.credential.DefaultPasswordService
+pm = org.apache.shiro.authc.credential.PasswordMatcher
+pm.passwordService = $ps
+
+jdbcRealm.dataSource = $ds
+jdbcRealm.credentialsMatcher = $pm
+shiro.loginUrl = /api/login
+
+sessionManager = org.apache.shiro.web.session.mgt.DefaultWebSessionManager
+cookie = org.apache.shiro.web.servlet.SimpleCookie
+cookie.name = JSESSIONID
+cookie.httpOnly = true
+sessionManager.sessionIdCookie = $cookie
+securityManager.sessionManager = $sessionManager
+securityManager.sessionManager.globalSessionTimeout = 86400000
+
+
+[urls]
+/** = authc
+/api/version = anon
+/api/interpreter/setting/restart/** = authc
+/api/interpreter/** = authc, roles[admin]
+/api/configurations/** = authc, roles[admin]
+/api/credential/** = authc, roles[admin]
+
+
+[roles]
+role1 = *
+role2 = *
+role3 = *
+admin = *
+
+
+# --------------------------------------
+# Fetch MySQL Connector Library
+# fedora@zeppelin
+
+pushd /home/fedora/zeppelin-0.10.0-bin-all/lib/
+    wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.28/mysql-connector-java-8.0.28.jar
+popd
+
+
+# --------------------------------------
+# Generate a SHA256 Username
+# fedora@zeppelin
+
+wget https://repo1.maven.org/maven2/org/apache/shiro/tools/shiro-tools-hasher/1.9.0/shiro-tools-hasher-1.9.0-cli.jar
+
+java -jar shiro-tools-hasher-1.9.0-cli.jar -p
+
+
+
+# --------------------------------------
+# Create new User
+# fedora@zeppelin
+
+mysql -u root -p
+INSERT INTO users (username, password) VALUES ('gaiauser', '$shiro1$SHA-256$500000$oc+p4G.............Z3a+9F8NZr4npCzCDouyc=');
+
+
+
+# --------------------------------------
+# Login to Zeppelin as 'gaiauser'
+# fedora@zeppelin
+
+# Create Notebook [SUCCESS]
+# Try to access Interpreters page [SUCCESS]
+# Log out and Log in again to see if notebook still exists [SUCCESS]
+# Logout [SUCCESS]
+
+
+# ------------------------------------------------------------------------
+# Create a new user, and check that login works without a Zeppelin restart
+# fedora@zeppelin
+
+mysql -u root -p
+
+INSERT INTO users (username, password) VALUES ('gaiauser', '$shiro1$SHA-256$500000$oc............+9F8NZr4npCzCDouyc=');
+
+# Login to Zeppelin as new user [SUCCESS]
+
+

--- a/notes/stv/20220407-create-user-database.txt
+++ b/notes/stv/20220407-create-user-database.txt
@@ -1,0 +1,91 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2022, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+
+# Create MySQL Database for storing shiro user credentials
+
+
+# Create VM in the 'data' project of the arcus Openstack
+# Fedora 31
+# tiny flavour
+# 3306 Port Open
+# Public IP address: 128.232.222.125
+
+
+
+# --------------------------------------
+# Generate a SHA256 passwords
+# fedora@zeppelin
+
+sudo yum install java
+wget https://repo1.maven.org/maven2/org/apache/shiro/tools/shiro-tools-hasher/1.9.0/shiro-tools-hasher-1.9.0-cli.jar
+
+java -jar shiro-tools-hasher-1.9.0-cli.jar -p
+> Password to hash: 
+..
+
+# Repeat and store output for each of our Zeppelin users 
+
+
+
+# -------------------------------------------------
+# Login to MySQL, create database, user, tables
+# fedora@mysql-node
+
+mysql -u root -p
+
+CREATE DATABASE zeppelin;
+USE zeppelin;
+CREATE USER 'zeppelin'@'128.232.222%' IDENTIFIED BY 'PASS';
+CREATE TABLE users (username TEXT, password TEXT, password_salt TEXT);
+CREATE TABLE user_roles (username TEXT, role_name TEXT);
+CREATE TABLE user_permissions (username TEXT, permission TEXT);
+GRANT ALL PRIVILEGES ON zeppelin.users TO 'zeppelin'@'128.232.222%';
+GRANT ALL PRIVILEGES ON zeppelin.user_roles TO 'zeppelin'@'128.232.222%';
+GRANT ALL PRIVILEGES ON zeppelin.user_permissions TO 'zeppelin'@'128.232.222%';
+
+
+# Create Zeppelin users
+
+INSERT INTO users (username, password) VALUES ('gaiauser', '$shiro1$SHA-256$500000.....gPbBTS6OTh8jcFqa0='); 
+INSERT INTO users (username, password) VALUES ('dcr', '$shiro1$SHA-256$500.....YFz8sOK3CbA='); 
+INSERT INTO users (username, password) VALUES ('nch', '$shiro1$SHA-256$500.....ovkyrmkMdZP5nfnnc='); 
+INSERT INTO users (username, password) VALUES ('zrq', '$shiro1$SHA-256$500.....2j39oO0YfocXVuVdAxDI='); 
+INSERT INTO users (username, password) VALUES ('stv', '$shiro1$SHA-256$50.....XiYAl1fkKkUWf4zxehy9DOkCg='); 
+INSERT INTO users (username, password) VALUES ('admin', '$shiro1$SHA-256$5.....W+MgZljx1ezUZm+4d1o='); 
+INSERT INTO users (username, password) VALUES ('yrvafhom', '$shiro1$SHA-256$500.....a4RFonBxyKb5MN9Xvz8jOXQk='); 
+
+# Create test users
+
+INSERT INTO users (username, password) VALUES ('gaiauser1', '$shiro1$SHA-256$50.....cvRLa+APCE+D65hyY0w='); 
+INSERT INTO users (username, password) VALUES ('gaiauser2', '$shiro1$SHA-256$500000.....iP2gdFIYg1l6+HL8aXm6CU='); 
+INSERT INTO users (username, password) VALUES ('gaiauser3', '$shiro1$SHA-256$500000$hHWLx.....rgziqwtVaLgJyzwbGGBEYQ8='); 
+
+# Create roles
+
+INSERT INTO user_roles (username, role_name) VALUES ('admin', 'admin'); 
+INSERT INTO user_roles (username, role_name) VALUES ('dcr', 'user'); 
+INSERT INTO user_roles (username, role_name) VALUES ('nch', 'user'); 
+INSERT INTO user_roles (username, role_name) VALUES ('zrq', 'user'); 
+INSERT INTO user_roles (username, role_name) VALUES ('stv', 'user'); 
+INSERT INTO user_roles (username, role_name) VALUES ('yrvafhom', 'user'); 
+
+

--- a/notes/stv/20220407-test-deploy-01.txt
+++ b/notes/stv/20220407-test-deploy-01.txt
@@ -1,0 +1,204 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2022, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+
+    Target:
+
+        Run Test Deploy, and Benchmarks.
+        User Credentials are stored in a MySQL database
+
+    Result:
+  
+        SUCCESS (BUT SLOW)
+
+	
+
+# -----------------------------------------------------
+# Fetch target branch
+#[user@desktop]
+
+    source "${HOME:?}/aglais.env"
+    pushd "${AGLAIS_CODE}"
+      	git checkout 'feature/shiro-jdbc'
+
+    popd
+
+
+# -----------------------------------------------------
+# Create a container to work with.
+#[user@desktop]
+
+    source "${HOME:?}/aglais.env"
+
+    podman run \
+        --rm \
+        --tty \
+        --interactive \
+        --name ansibler \
+        --hostname ansibler \
+        --publish 3000:3000 \
+        --publish 8088:8088 \
+        --env "SSH_AUTH_SOCK=/mnt/ssh_auth_sock" \
+        --volume "${SSH_AUTH_SOCK}:/mnt/ssh_auth_sock:rw,z" \
+        --volume "${HOME:?}/clouds.yaml:/etc/openstack/clouds.yaml:ro,z" \
+        --volume "${AGLAIS_CODE:?}/deployments:/deployments:ro,z" \
+        atolmis/ansible-client:2021.08.25 \
+        bash
+
+
+
+# -----------------------------------------------------
+# Set the cloud and configuration.
+#[root@ansibler]
+
+    cloudname=iris-gaia-red
+
+    configname=zeppelin-26.43-spark-6.26.43
+
+
+# -----------------------------------------------------
+# Delete everything.
+#[root@ansibler]
+
+    time \
+        /deployments/openstack/bin/delete-all.sh \
+            "${cloudname:?}"
+
+        > Done
+
+
+
+# -----------------------------------------------------
+# Create everything, using the new config.
+#[root@ansibler]
+
+    time \
+        /deployments/hadoop-yarn/bin/create-all.sh \
+            "${cloudname:?}" \
+            "${configname:?}"   \
+        | tee /tmp/create-all.log
+
+
+        > Done
+
+
+# ---------------------------------------------------------------------------------
+# Run Basic user test
+#[root@ansibler]
+	
+    num_users=1
+    concurrent=True
+    test_level="basic"
+
+    # Restart Zeppelin
+    time \
+        /deployments/hadoop-yarn/bin/restart-zeppelin.sh
+
+    time \
+        /deployments/hadoop-yarn/bin/run-tests.sh \
+            "${cloudname:?}" \
+            "${configname:?}" \
+            "${test_level:?}"  \
+	     ${concurrent:?}  \
+	     ${num_users:?}  \
+        | tee /tmp/run-tests-basic.log	
+
+
+# Results:
+
+
+[{
+	'GaiaDMPSetup': {
+		'result': 'PASS',
+		'outputs': {
+			'valid': True
+		},
+		'time': {
+			'result': 'FAST',
+			'elapsed': '40.20',
+			'expected': '45.00',
+			'percent': '-10.67',
+			'start': '2022-04-07T17:54:51.064629',
+			'finish': '2022-04-07T17:55:31.262823'
+		},
+		'logs': ''
+	},
+	'Mean_proper_motions_over_the_sky': {
+		'result': 'PASS',
+		'outputs': {
+			'valid': True
+		},
+		'time': {
+			'result': 'SLOW',
+			'elapsed': '63.30',
+			'expected': '55.00',
+			'percent': '15.10',
+			'start': '2022-04-07T17:55:31.263281',
+			'finish': '2022-04-07T17:56:34.567854'
+		},
+		'logs': ''
+	},
+	'Source_counts_over_the_sky.json': {
+		'result': 'PASS',
+		'outputs': {
+			'valid': True
+		},
+		'time': {
+			'result': 'SLOW',
+			'elapsed': '24.20',
+			'expected': '22.00',
+			'percent': '9.99',
+			'start': '2022-04-07T17:56:34.568225',
+			'finish': '2022-04-07T17:56:58.765882'
+		},
+		'logs': ''
+	},
+	'Good_astrometric_solutions_via_ML_Random_Forrest_classifier': {
+		'result': 'PASS',
+		'outputs': {
+			'valid': True
+		},
+		'time': {
+			'result': 'SLOW',
+			'elapsed': '591.50',
+			'expected': '500.00',
+			'percent': '18.30',
+			'start': '2022-04-07T17:56:58.766738',
+			'finish': '2022-04-07T18:06:50.264390'
+		},
+		'logs': ''
+	},
+	'Library_Validation.json': {
+		'result': 'PASS',
+		'outputs': {
+			'valid': True
+		},
+		'time': {
+			'result': 'FAST',
+			'elapsed': '8.91',
+			'expected': '60.00',
+			'percent': '-85.15',
+			'start': '2022-04-07T18:06:50.264563',
+			'finish': '2022-04-07T18:06:59.175004'
+		},
+		'logs': ''
+	}
+}]

--- a/notes/stv/20220412-test-deploy-01.txt
+++ b/notes/stv/20220412-test-deploy-01.txt
@@ -1,0 +1,260 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2022, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+
+    Target:
+
+        Run Test Deploy, and Benchmarks
+
+    Result:
+  
+
+
+
+# -----------------------------------------------------
+# Fetch target branch
+#[user@desktop]
+
+    source "${HOME:?}/aglais.env"
+    pushd "${AGLAIS_CODE}"
+      	git checkout 'feature/shiro-jdbc'
+
+    popd
+
+
+# -----------------------------------------------------
+# Create a container to work with.
+#[user@desktop]
+
+    source "${HOME:?}/aglais.env"
+
+    podman run \
+        --rm \
+        --tty \
+        --interactive \
+        --name ansibler \
+        --hostname ansibler \
+        --publish 3000:3000 \
+        --publish 8088:8088 \
+        --env "SSH_AUTH_SOCK=/mnt/ssh_auth_sock" \
+        --volume "${SSH_AUTH_SOCK}:/mnt/ssh_auth_sock:rw,z" \
+        --volume "${HOME:?}/clouds.yaml:/etc/openstack/clouds.yaml:ro,z" \
+        --volume "${AGLAIS_CODE:?}/deployments:/deployments:ro,z" \
+        atolmis/ansible-client:2021.08.25 \
+        bash
+
+
+
+# -----------------------------------------------------
+# Set the cloud and configuration.
+#[root@ansibler]
+
+    cloudname=iris-gaia-red
+
+    configname=zeppelin-26.43-spark-6.26.43
+
+
+# -----------------------------------------------------
+# Delete everything.
+#[root@ansibler]
+
+    time \
+        /deployments/openstack/bin/delete-all.sh \
+            "${cloudname:?}"
+
+        > Done
+
+
+
+# -----------------------------------------------------
+# Create everything, using the new config.
+#[root@ansibler]
+
+    time \
+        /deployments/hadoop-yarn/bin/create-all.sh \
+            "${cloudname:?}" \
+            "${configname:?}"   \
+            "test"\
+        | tee /tmp/create-all.log
+
+
+        > Done
+
+
+# -----------------------------------------------------
+# Validate that MySQL users were created
+#[fedora@zeppelin]
+
+mysql -u zeppelin -p 
+
+USE zeppelin;
+
+SELECT * FROM users;
++------------+----------------------------------------------------------------------------------------------+---------------+
+| username   | password                                                                                     | password_salt |
++------------+----------------------------------------------------------------------------------------------+---------------+
+| gaiauser1  | $shiro1$SHA-256$axaB+8cNE5B1oe4w58=             ...                                          | NULL          |
+| gaiauser2  | $shiro1$SHA-256$oJS912hLLnMsjGKHA=               ...                                         | NULL          |
+| gaiauser3  | $shiro1$SHA-256$500sWCurgQLtfF+JJ4Nvoztdv850=     ...                                        | NULL          |
+
+....
+
+10 rows in set (0.00 sec)
+
+
+# -----------------------------------------------------
+# Validate that we can login to Zeppelin as 'gaiauser1'
+# [firefox]
+
+1. Login [Success]
+2. Create a test notebook [Success]
+3. Log out and Log in again, Test that we can see the notebook we created [Success]
+4. Create new user in database, check that we can login without restarting Zeppelin [Success]
+
+	# --------------------------------------------
+	# Generate a SHA256 password for our new user
+	# fedora@zeppelin
+
+		sudo yum install java
+		wget https://repo1.maven.org/maven2/org/apache/shiro/tools/shiro-tools-hasher/1.9.0/shiro-tools-hasher-1.9.0-cli.jar
+
+		java -jar shiro-tools-hasher-1.9.0-cli.jar -p
+		> Password to hash: 
+		..
+
+	        mysql -u root -p
+         	
+                  > INSERT INTO users (username, password) VALUES ('gaiauser11', '$shiro1$SHA-256$50....TWCqeXXcmv1v+yZ0X+JHPWYeQ=');
+                  > INSERT INTO user_roles (username, role_name) VALUES ('gaiauser11', 'admin'); 
+
+
+        # Login with new uer (gaiauser11)
+        # Login successful
+
+5. Check that the new user can edit admin protected configurations in Zeppelin (e.g. Changing and Restarting Interpreters) [Success]
+
+
+# -------------------------------------------------------------------------------
+# Run Basic Test
+#
+#[root@ansibler]
+
+
+    cloudname=iris-gaia-red
+    configname=zeppelin-26.43-spark-6.26.43
+    num_users=1
+    concurrent=True
+    test_level="basic"
+
+    # Restart Zeppelin
+    time \
+        /deployments/hadoop-yarn/bin/restart-zeppelin.sh
+
+    time \
+        /deployments/hadoop-yarn/bin/run-tests.sh \
+            "${cloudname:?}" \
+            "${configname:?}" \
+            "${test_level:?}"  \
+	     ${concurrent:?}  \
+	     ${num_users:?}  \
+        | tee /tmp/run-tests-basic.log	
+
+
+# -----------------------------------------
+# Results:
+
+[{
+	'GaiaDMPSetup': {
+		'result': 'PASS',
+		'outputs': {
+			'valid': True
+		},
+		'time': {
+			'result': 'FAST',
+			'elapsed': '40.46',
+			'expected': '45.00',
+			'percent': '-10.08',
+			'start': '2022-04-12T17:23:14.374285',
+			'finish': '2022-04-12T17:23:54.836146'
+		},
+		'logs': ''
+	},
+	'Mean_proper_motions_over_the_sky': {
+		'result': 'PASS',
+		'outputs': {
+			'valid': True
+		},
+		'time': {
+			'result': 'SLOW',
+			'elapsed': '61.23',
+			'expected': '55.00',
+			'percent': '11.33',
+			'start': '2022-04-12T17:23:54.836589',
+			'finish': '2022-04-12T17:24:56.065486'
+		},
+		'logs': ''
+	},
+	'Source_counts_over_the_sky.json': {
+		'result': 'PASS',
+		'outputs': {
+			'valid': True
+		},
+		'time': {
+			'result': 'SLOW',
+			'elapsed': '22.86',
+			'expected': '22.00',
+			'percent': '3.90',
+			'start': '2022-04-12T17:24:56.066137',
+			'finish': '2022-04-12T17:25:18.924135'
+		},
+		'logs': ''
+	},
+	'Good_astrometric_solutions_via_ML_Random_Forrest_classifier': {
+		'result': 'PASS',
+		'outputs': {
+			'valid': True
+		},
+		'time': {
+			'result': 'SLOW',
+			'elapsed': '582.73',
+			'expected': '500.00',
+			'percent': '16.55',
+			'start': '2022-04-12T17:25:18.924987',
+			'finish': '2022-04-12T17:35:01.656447'
+		},
+		'logs': ''
+	},
+	'Library_Validation.json': {
+		'result': 'PASS',
+		'outputs': {
+			'valid': True
+		},
+		'time': {
+			'result': 'FAST',
+			'elapsed': '8.71',
+			'expected': '60.00',
+			'percent': '-85.48',
+			'start': '2022-04-12T17:35:01.656611',
+			'finish': '2022-04-12T17:35:10.371314'
+		},
+		'logs': ''
+	}
+}]

--- a/notes/stv/20220413-test-deploy-01.txt
+++ b/notes/stv/20220413-test-deploy-01.txt
@@ -1,0 +1,328 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2022, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+
+    Target:
+
+        Run Test Deploy, and Benchmarks
+
+    Result:
+  
+
+
+
+# -----------------------------------------------------
+# Fetch target branch
+#[user@desktop]
+
+    source "${HOME:?}/aglais.env"
+    pushd "${AGLAIS_CODE}"
+      	git checkout 'feature/shiro-jdbc'
+
+    popd
+
+
+# -----------------------------------------------------
+# Create a container to work with.
+#[user@desktop]
+
+    source "${HOME:?}/aglais.env"
+
+    podman run \
+        --rm \
+        --tty \
+        --interactive \
+        --name ansibler \
+        --hostname ansibler \
+        --publish 3000:3000 \
+        --publish 8088:8088 \
+        --env "SSH_AUTH_SOCK=/mnt/ssh_auth_sock" \
+        --volume "${SSH_AUTH_SOCK}:/mnt/ssh_auth_sock:rw,z" \
+        --volume "${HOME:?}/clouds.yaml:/etc/openstack/clouds.yaml:ro,z" \
+        --volume "${AGLAIS_CODE:?}/deployments:/deployments:ro,z" \
+        atolmis/ansible-client:2021.08.25 \
+        bash
+
+
+
+# -----------------------------------------------------
+# Set the cloud and configuration.
+#[root@ansibler]
+
+    cloudname=iris-gaia-red
+
+    configname=zeppelin-26.43-spark-6.26.43
+
+
+# -----------------------------------------------------
+# Delete everything.
+#[root@ansibler]
+
+    time \
+        /deployments/openstack/bin/delete-all.sh \
+            "${cloudname:?}"
+
+        > Done
+
+
+
+# -----------------------------------------------------
+# Create everything, using the new config.
+#[root@ansibler]
+
+    time \
+        /deployments/hadoop-yarn/bin/create-all.sh \
+            "${cloudname:?}" \
+            "${configname:?}"   \
+        | tee /tmp/create-all.log
+
+
+        > Done
+
+# -----------------------------------------------------
+# Create (test) users.
+#[root@ansibler]
+
+    time \
+        /deployments/hadoop-yarn/bin/create-users.sh \
+            "${cloudname:?}" \
+            "${configname:?}"   \
+            "test"   \
+        | tee /tmp/create-users.log
+
+
+# -----------------------------------------------------
+# Validate that MySQL users were created
+#[fedora@zeppelin]
+
+mysql -u zeppelin -p 
+
+USE zeppelin;
+
+SELECT * FROM users;
++------------+----------------------------------------------------------------------------------------------+---------------+
+| username   | password                                                                                     | password_salt |
++------------+----------------------------------------------------------------------------------------------+---------------+
+| gaiauser1  | $shiro1$SHA-256$axaB+8cNE5B1oe4w58=             ...                                          | NULL          |
+| gaiauser2  | $shiro1$SHA-256$oJS912hLLnMsjGKHA=               ...                                         | NULL          |
+| gaiauser3  | $shiro1$SHA-256$500sWCurgQLtfF+JJ4Nvoztdv850=     ...                                        | NULL          |
+
+....
+
+10 rows in set (0.00 sec)
+
+
+# -----------------------------------------------------
+# Validate that we can login to Zeppelin as 'gaiauser1'
+# [firefox]
+
+1. Login [Success]
+2. Create a test notebook [Success]
+3. Log out and Log in again, Test that we can see the notebook we created [Success]
+4. Create new user in database, check that we can login without restarting Zeppelin [Success]
+
+	# --------------------------------------------
+	# Generate a SHA256 password for our new user
+	# fedora@zeppelin
+
+		sudo yum install java
+		wget https://repo1.maven.org/maven2/org/apache/shiro/tools/shiro-tools-hasher/1.9.0/shiro-tools-hasher-1.9.0-cli.jar
+
+		java -jar shiro-tools-hasher-1.9.0-cli.jar -p
+		> Password to hash: 
+		..
+
+	        mysql -u root -p
+         	
+                  > INSERT INTO users (username, password) VALUES ('gaiauser11', '$shiro1$SHA-256$50....TWCqeXXcmv1v+yZ0X+JHPWYeQ=');
+                  > INSERT INTO user_roles (username, role_name) VALUES ('gaiauser11', 'admin'); 
+
+
+        # Login with new uer (gaiauser11)
+        # Login successful
+
+5. Check that the new user can edit admin protected configurations in Zeppelin (e.g. Changing and Restarting Interpreters) [Success]
+
+
+# -------------------------------------------------------------------------------
+# Run Basic Test
+#
+#[root@ansibler]
+
+
+    cloudname=iris-gaia-red
+    configname=zeppelin-26.43-spark-6.26.43
+    num_users=1
+    concurrent=True
+    test_level="basic"
+
+    # Restart Zeppelin
+    time \
+        /deployments/hadoop-yarn/bin/restart-zeppelin.sh
+
+    time \
+        /deployments/hadoop-yarn/bin/run-tests.sh \
+            "${cloudname:?}" \
+            "${configname:?}" \
+            "${test_level:?}"  \
+	     ${concurrent:?}  \
+	     ${num_users:?}  \
+        | tee /tmp/run-tests-basic.log	
+
+
+# -----------------------------------------
+# Results:
+
+[[{
+	'GaiaDMPSetup': {
+		'result': 'PASS',
+		'outputs': {
+			'valid': True
+		},
+		'time': {
+			'result': 'FAST',
+			'elapsed': '39.93',
+			'expected': '45.00',
+			'percent': '-11.27',
+			'start': '2022-04-13T11:36:13.038304',
+			'finish': '2022-04-13T11:36:52.968214'
+		},
+		'logs': ''
+	},
+	'Mean_proper_motions_over_the_sky': {
+		'result': 'PASS',
+		'outputs': {
+			'valid': True
+		},
+		'time': {
+			'result': 'SLOW',
+			'elapsed': '56.25',
+			'expected': '55.00',
+			'percent': '2.28',
+			'start': '2022-04-13T11:36:52.968493',
+			'finish': '2022-04-13T11:37:49.221184'
+		},
+		'logs': ''
+	},
+	'Source_counts_over_the_sky.json': {
+		'result': 'PASS',
+		'outputs': {
+			'valid': True
+		},
+		'time': {
+			'result': 'FAST',
+			'elapsed': '20.04',
+			'expected': '22.00',
+			'percent': '-8.89',
+			'start': '2022-04-13T11:37:49.221431',
+			'finish': '2022-04-13T11:38:09.264861'
+		},
+		'logs': ''
+	},
+	'Good_astrometric_solutions_via_ML_Random_Forrest_classifier': {
+		'result': 'PASS',
+		'outputs': {
+			'valid': True
+		},
+		'time': {
+			'result': 'SLOW',
+			'elapsed': '543.62',
+			'expected': '500.00',
+			'percent': '8.72',
+			'start': '2022-04-13T11:38:09.265237',
+			'finish': '2022-04-13T11:47:12.880706'
+		},
+		'logs': ''
+	},
+	'Library_Validation.json': {
+		'result': 'PASS',
+		'outputs': {
+			'valid': True
+		},
+		'time': {
+			'result': 'FAST',
+			'elapsed': '8.29',
+			'expected': '60.00',
+			'percent': '-86.18',
+			'start': '2022-04-13T11:47:12.880919',
+			'finish': '2022-04-13T11:47:21.175598'
+		},
+		'logs': ''
+	}
+}]
+
+
+
+# -----------------------------------------------------
+# Repeat deploy, this time create (prod users)
+
+
+# -----------------------------------------------------
+# Delete everything.
+#[root@ansibler]
+
+    time \
+        /deployments/openstack/bin/delete-all.sh \
+            "${cloudname:?}"
+
+        > Done
+
+
+
+# -----------------------------------------------------
+# Create everything, using the new config.
+#[root@ansibler]
+
+    time \
+        /deployments/hadoop-yarn/bin/create-all.sh \
+            "${cloudname:?}" \
+            "${configname:?}"   \
+        | tee /tmp/create-all.log
+
+
+        > Done
+
+# -----------------------------------------------------
+# Create (prod) users.
+#[root@ansibler]
+
+    time \
+        /deployments/hadoop-yarn/bin/create-users.sh \
+            "${cloudname:?}" \
+            "${configname:?}"   \
+            "prod"   \
+        | tee /tmp/create-users.log
+
+
+
+# -----------------------------------------------------
+# Import aglais notebooks
+#[fedora@zeppelin]
+   pushd /home/fedora/zeppelin-0.10.0-bin-all
+	   rm -r notebook/
+	   git clone https://github.com/wfau/aglais-notebooks notebook
+	   ./bin/zeppelin-daemon.sh restart
+   popd
+
+
+# Login as gaiauser1 [Success]
+# Create notebook (only accessible to gaiauser1 by default) [Success]
+# Logout, Login as stv / Ensure gaiauser1's notebook is not accessible [Success]

--- a/notes/stv/20220427-testing-deploys-pr-changes.txt
+++ b/notes/stv/20220427-testing-deploys-pr-changes.txt
@@ -1,0 +1,346 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2022, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+
+    Target:
+
+        Run Test Deploy, and Benchmarks
+        Test using the following auth types: [prod, jdbc, test]
+
+    Result:
+  
+        PASS (SLOW)
+
+
+# -----------------------------------------------------
+# Fetch target branch
+#[user@desktop]
+
+    source "${HOME:?}/aglais.env"
+    pushd "${AGLAIS_CODE}"
+      	git checkout 'feature/shiro-jdbc'
+
+    popd
+
+
+# -----------------------------------------------------
+# Create a container to work with.
+#[user@desktop]
+
+    source "${HOME:?}/aglais.env"
+
+    podman run \
+        --rm \
+        --tty \
+        --interactive \
+        --name ansibler \
+        --hostname ansibler \
+        --publish 3000:3000 \
+        --publish 8088:8088 \
+        --env "SSH_AUTH_SOCK=/mnt/ssh_auth_sock" \
+        --volume "${SSH_AUTH_SOCK}:/mnt/ssh_auth_sock:rw,z" \
+        --volume "${HOME:?}/clouds.yaml:/etc/openstack/clouds.yaml:ro,z" \
+        --volume "${AGLAIS_CODE:?}/deployments:/deployments:ro,z" \
+        --volume "${AGLAIS_SECRETS:?}/sql/:/deployments/common/zeppelin/sql/:ro,z" \
+        atolmis/ansible-client:2021.08.25 \
+        bash
+
+
+# Note:
+
+# When running with auth-type set to "jdbc" or "test", the scripts expect to find an auth.sql or auth-test.sql file accordingly, in the /deployments/common/zeppelin/sql/ directory of the ansibler container
+# Here we mount this from a local directory that contains these files with the users we want to create
+# The auth files need to look like this:
+
+# Example auth.sql file:
+
+USE zeppelin;
+
+# Create test users
+
+INSERT INTO users (username, password) VALUES ('gaiauser1', '$shiro.....4w58=');
+
+# Create roles
+
+INSERT INTO user_roles (username, role_name) VALUES ('gaiauser1', 'user');
+
+
+# End Example
+
+
+
+# Deploy "prod"
+
+# -----------------------------------------------------
+# Set the cloud and configuration.
+#[root@ansibler]
+
+    cloudname=iris-gaia-red
+
+    configname=zeppelin-26.43-spark-6.26.43
+
+
+# -----------------------------------------------------
+# Delete everything.
+#[root@ansibler]
+
+    time \
+        /deployments/openstack/bin/delete-all.sh \
+            "${cloudname:?}"
+
+        > Done
+
+
+
+# -----------------------------------------------------
+# Create everything, using the new config.
+#[root@ansibler]
+
+    time \
+        /deployments/hadoop-yarn/bin/create-all.sh \
+            "${cloudname:?}" \
+            "${configname:?}"   \
+        | tee /tmp/create-all.log
+
+
+        > Done
+
+# -----------------------------------------------------
+# Create (test) users.
+#[root@ansibler]
+
+    time \
+        /deployments/hadoop-yarn/bin/create-users.sh \
+            "${cloudname:?}" \
+            "${configname:?}"   \
+            "prod"   \
+        | tee /tmp/create-users.log
+
+
+
+# -----------------------------------------------------
+# Validation
+
+
+# Validate that shiro file was created with the users in it [Success]
+# Validate that we can login using one of the users [Success]
+# Validate that we can create and run a simple notebook [Success]
+
+
+
+
+# Deploy "jdbc"
+
+
+# -----------------------------------------------------
+# Delete everything.
+#[root@ansibler]
+
+    time \
+        /deployments/openstack/bin/delete-all.sh \
+            "${cloudname:?}"
+
+        > Done
+
+
+
+# -----------------------------------------------------
+# Create everything, using the new config.
+#[root@ansibler]
+
+    time \
+        /deployments/hadoop-yarn/bin/create-all.sh \
+            "${cloudname:?}" \
+            "${configname:?}"   \
+        | tee /tmp/create-all.log
+
+
+        > Done
+
+# -----------------------------------------------------
+# Create (test) users.
+#[root@ansibler]
+
+    time \
+        /deployments/hadoop-yarn/bin/create-users.sh \
+            "${cloudname:?}" \
+            "${configname:?}"   \
+            "jdbc"   \
+        | tee /tmp/create-users.log
+
+
+
+# -----------------------------------------------------
+# Validation
+
+# Validate that shiro file was created with the credentials to the MySQL user db in it [Success]
+# Validate that we can login using one of the users [Success]
+# Validate that we can create and run a simple notebook [Success]
+
+
+
+# Deploy "test"
+
+
+# -----------------------------------------------------
+# Delete everything.
+#[root@ansibler]
+
+    time \
+        /deployments/openstack/bin/delete-all.sh \
+            "${cloudname:?}"
+
+        > Done
+
+
+
+# -----------------------------------------------------
+# Create everything, using the new config.
+#[root@ansibler]
+
+    time \
+        /deployments/hadoop-yarn/bin/create-all.sh \
+            "${cloudname:?}" \
+            "${configname:?}"   \
+        | tee /tmp/create-all.log
+
+
+        > Done
+
+# -----------------------------------------------------
+# Create (test) users.
+#[root@ansibler]
+
+    time \
+        /deployments/hadoop-yarn/bin/create-users.sh \
+            "${cloudname:?}" \
+            "${configname:?}"   \
+            "test"   \
+        | tee /tmp/create-users.log
+
+
+
+# -------------------------------------------------------------------------------
+# Run Basic Test
+#
+#[root@ansibler]
+
+
+    cloudname=iris-gaia-red
+    configname=zeppelin-26.43-spark-6.26.43
+    num_users=1
+    concurrent=True
+    test_level="basic"
+
+    # Restart Zeppelin
+    time \
+        /deployments/hadoop-yarn/bin/restart-zeppelin.sh
+
+    time \
+        /deployments/hadoop-yarn/bin/run-tests.sh \
+            "${cloudname:?}" \
+            "${configname:?}" \
+            "${test_level:?}"  \
+	     ${concurrent:?}  \
+	     ${num_users:?}  \
+        | tee /tmp/run-tests-basic.log	
+
+
+# -----------------------------------------
+# Results:
+
+[{
+	'GaiaDMPSetup': {
+		'result': 'PASS',
+		'outputs': {
+			'valid': True
+		},
+		'time': {
+			'result': 'FAST',
+			'elapsed': '38.84',
+			'expected': '45.00',
+			'percent': '-13.68',
+			'start': '2022-04-27T14:49:24.001217',
+			'finish': '2022-04-27T14:50:02.843177'
+		},
+		'logs': ''
+	},
+	'Mean_proper_motions_over_the_sky': {
+		'result': 'PASS',
+		'outputs': {
+			'valid': True
+		},
+		'time': {
+			'result': 'SLOW',
+			'elapsed': '57.27',
+			'expected': '55.00',
+			'percent': '4.12',
+			'start': '2022-04-27T14:50:02.843440',
+			'finish': '2022-04-27T14:51:00.110352'
+		},
+		'logs': ''
+	},
+	'Source_counts_over_the_sky.json': {
+		'result': 'PASS',
+		'outputs': {
+			'valid': True
+		},
+		'time': {
+			'result': 'FAST',
+			'elapsed': '20.56',
+			'expected': '22.00',
+			'percent': '-6.57',
+			'start': '2022-04-27T14:51:00.110540',
+			'finish': '2022-04-27T14:51:20.666071'
+		},
+		'logs': ''
+	},
+	'Good_astrometric_solutions_via_ML_Random_Forrest_classifier': {
+		'result': 'PASS',
+		'outputs': {
+			'valid': True
+		},
+		'time': {
+			'result': 'SLOW',
+			'elapsed': '546.09',
+			'expected': '500.00',
+			'percent': '9.22',
+			'start': '2022-04-27T14:51:20.666434',
+			'finish': '2022-04-27T15:00:26.753003'
+		},
+		'logs': ''
+	},
+	'Library_Validation.json': {
+		'result': 'PASS',
+		'outputs': {
+			'valid': True
+		},
+		'time': {
+			'result': 'FAST',
+			'elapsed': '8.97',
+			'expected': '60.00',
+			'percent': '-85.04',
+			'start': '2022-04-27T15:00:26.753194',
+			'finish': '2022-04-27T15:00:35.727367'
+		},
+		'logs': ''
+	}
+}]


### PR DESCRIPTION
Introduces two new playbooks for creating & importing users and a new script for running the create & import process.
The new script takes a parameter for the deploy type (prod | test) and creates the appropriate set of users.
The user credentials (auth.sql or auth-test.sql) are expected to be found under ../../common/zeppelin/sql/. 
For new deploys, the credentials need to be found there, and passwords need to be hashed using the "shiro-tools-hasher-1.9.0-cli.jar" tool.