### PR TITLE
Fixing empty spaces in create-user-scripts yaml file

### DIFF
--- a/deployments/hadoop-yarn/ansible/39-create-user-scripts.yml
+++ b/deployments/hadoop-yarn/ansible/39-create-user-scripts.yml
@@ -125,10 +125,10 @@
             --data "password=${NEW_PASSWORD:?}" \
             ${ZEPPELIN_URL:?}/api/login 
 
-           curl --silent --cookie "${zepcookies:?}" "${ZEPPELIN_URL:?}/api/notebook"| jq -r '.body[] | select(.path | startswith("/Public")) | [.id, .path] | @tsv' |
-             while IFS=$'\t' read -r id path; do
-               curl -L         -H 'Content-Type: application/json'         -d "{'name': '${path/Public Examples/Users/$NEW_USERNAME}' }"        --request POST         --cookie "${zepcookies:?}"    $ZEPPELIN_URL/api/notebook/$id
-             done
+            curl --silent --cookie "${zepcookies:?}" "${ZEPPELIN_URL:?}/api/notebook"| jq -r '.body[] | select(.path | startswith("/Public")) | [.id, .path] | @tsv' |
+            while IFS=$'\t' read -r id path; do
+              curl -L         -H 'Content-Type: application/json'         -d "{'name': '${path/Public Examples/Users/$NEW_USERNAME}' }"        --request POST         --cookie "${zepcookies:?}"    $ZEPPELIN_URL/api/notebook/$id
+            done
 
     
     add_user: |


### PR DESCRIPTION
There seems to have been some misalignment in the yaml file that made it in the last PR. 
Quickfix included here.