### PR TITLE
Enable user impersonation for all interpreters

### DIFF
--- a/deployments/common/zeppelin/interpreter.json
+++ b/deployments/common/zeppelin/interpreter.json
@@ -1,4 +1,4 @@
-
+{
   "interpreterSettings": {
      "python": {
       "id": "python",

--- a/deployments/common/zeppelin/interpreter.json
+++ b/deployments/common/zeppelin/interpreter.json
@@ -1,4 +1,4 @@
-{
+
   "interpreterSettings": {
      "python": {
       "id": "python",
@@ -95,10 +95,12 @@
       "option": {
         "remote": true,
         "port": -1,
+        "perNote": "shared",
+        "perUser": "isolated",
         "isExistingProcess": false,
         "setPermission": false,
         "owners": [],
-        "isUserImpersonate": false
+        "isUserImpersonate": true
       }
     },
     "sh": {
@@ -185,10 +187,12 @@
       "option": {
         "remote": true,
         "port": -1,
+        "perNote": "shared",
+        "perUser": "isolated",
         "isExistingProcess": false,
         "setPermission": false,
         "owners": [],
-        "isUserImpersonate": false
+        "isUserImpersonate": true
       }
     },
     "spark": {
@@ -507,7 +511,7 @@
         "isExistingProcess": false,
         "setPermission": false,
         "owners": [],
-        "isUserImpersonate": false
+        "isUserImpersonate": true
       }
     },
     "md": {
@@ -539,10 +543,12 @@
       "option": {
         "remote": true,
         "port": -1,
+        "perNote": "shared",
+        "perUser": "isolated",
         "isExistingProcess": false,
         "setPermission": false,
         "owners": [],
-        "isUserImpersonate": false
+        "isUserImpersonate": true
       }
     }
   },

--- a/deployments/hadoop-yarn/ansible/12-config-hadoop-core.yml
+++ b/deployments/hadoop-yarn/ansible/12-config-hadoop-core.yml
@@ -71,3 +71,17 @@
                 <value>{{hdtemplink}}</value>
             </property>
 
+            <property>
+                <name>hadoop.proxyuser.{{hduser}}.hosts</name>
+                <value>*</value>
+            </property>
+  
+            <property>
+                <name>hadoop.proxyuser.{{hduser}}.groups</name>
+                <value>*</value>
+            </property>
+
+            <property>
+                <name>hadoop.proxyuser.{{hduser}}.users</name>
+                <value>*</value>
+            </property>

--- a/deployments/hadoop-yarn/ansible/27-install-zeppelin.yml
+++ b/deployments/hadoop-yarn/ansible/27-install-zeppelin.yml
@@ -240,6 +240,10 @@
           export HADOOP_CONF_DIR={{hdhome}}/etc/hadoop
           export MASTER=yarn-client
 
+    - name: "Add group for Zeppelin Users"
+      become: true
+      command: groupadd {{ zepusersgroup }}
+
     - name: "Create [{{zephome}}/conf/zeppelin-env.sh]"
       become: true
       blockinfile:
@@ -247,8 +251,8 @@
         state: present
         create: true
         owner: "{{zepuser}}"
-        group: "{{zepuser}}"
-        mode:  'u=rw,g=r,o=r'
+        group: "{{zepusersgroup}}"
+        mode:  'u=rwx,g=rwx,o=r'
         insertafter: 'EOF'
         block: |
           export SPARK_HOME={{sphome}}
@@ -274,6 +278,10 @@
         group: "{{zepuser}}"
         mode: 0775
 
-    - name: "Add group for Zeppelin Users"
+    - name: Set folder permissions to 0775
       become: true
-      command: groupadd {{ zepusersgroup }}
+      file: path={{ item }} mode=0750 state=directory group={{zepusersgroup}}
+      with_items:
+        - '{{zephome}}'
+        - '{{zephome}}/conf/'
+        - '/home/{{zepuser}}'

--- a/deployments/hadoop-yarn/ansible/38-install-user-db.yml
+++ b/deployments/hadoop-yarn/ansible/38-install-user-db.yml
@@ -171,7 +171,7 @@
      copy:
        owner: "{{zepuser}}"
        group: "{{zepuser}}"
-       mode:  'u=rw,g=r,o=r'
+       mode:  '0700'
        dest:  "{{zephome}}/conf/shiro.ini"
        content: "{{ zeppelinshiro }}"
      tags:

--- a/deployments/hadoop-yarn/ansible/39-create-user-scripts.yml
+++ b/deployments/hadoop-yarn/ansible/39-create-user-scripts.yml
@@ -125,27 +125,31 @@
             --data "password=${NEW_PASSWORD:?}" \
             ${ZEPPELIN_URL:?}/api/login 
 
-           curl --silent --cookie "${zepcookies:?}" "${ZEPPELIN_URL:?}/api/notebook"| jq -r '.body[] | select(.path | startswith("/Public")) | [.id, .path] | @tsv' |
-             while IFS=$'\t' read -r id path; do
-               curl -L         -H 'Content-Type: application/json'         -d "{'name': '${path/Public Examples/Users/$NEW_USERNAME}' }"        --request POST         --cookie "${zepcookies:?}"    $ZEPPELIN_URL/api/notebook/$id
-             done
+            curl --silent --cookie "${zepcookies:?}" "${ZEPPELIN_URL:?}/api/notebook"| jq -r '.body[] | select(.path | startswith("/Public")) | [.id, .path] | @tsv' |
+            while IFS=$'\t' read -r id path; do
+              curl -L         -H 'Content-Type: application/json'         -d "{'name': '${path/Public Examples/Users/$NEW_USERNAME}' }"        --request POST         --cookie "${zepcookies:?}"    $ZEPPELIN_URL/api/notebook/$id
+            done
 
     
     add_user: |
             #!/bin/bash
-            printf "Create a new Zeppelin user"
-            printf "\n"
-            printf "Username: "
-            read NEW_USERNAME
-            
-            stty -echo
-            printf "Password: "
-            read NEW_PASSWORD
-            stty echo
-                        
-            printf "\n"
-            printf "User role: "
-            read NEW_USER_ROLE
+            if [ "$#" -ne 3 ]
+            then
+                
+                printf "Create a new Zeppelin user"
+                printf "\n"
+                printf "Username: "
+                read NEW_USERNAME
+                
+                stty -echo
+                printf "Password: "
+                read NEW_PASSWORD
+                stty echo
+                            
+                printf "\n"
+                printf "User role: "
+                read NEW_USER_ROLE
+            fi
 
             ZEPPELIN_URL="http://{{ zepipaddress }}:8080"
 

--- a/deployments/hadoop-yarn/ansible/40-create-shiro-file.yml
+++ b/deployments/hadoop-yarn/ansible/40-create-shiro-file.yml
@@ -71,7 +71,7 @@
       copy:
         owner: "{{zepuser}}"
         group: "{{zepuser}}"
-        mode:  'u=rw,g=r,o=r'
+        mode:  '0700'
         dest:  "{{zephome}}/conf/shiro.ini"
         content: "{{ zeppelinshiro }}"
       tags:

--- a/deployments/hadoop-yarn/bin/create-users.sh
+++ b/deployments/hadoop-yarn/bin/create-users.sh
@@ -67,31 +67,7 @@
 
 
 
-    # Import users
-
-    pushd "${treetop:?}/hadoop-yarn/ansible"
-
-
-        if [ "${authtype}" == "test" ]
-        then
-            ansible-playbook \
-                --inventory "${inventory:?}" \
-                --extra-vars "users_import_file=auth-test.sql" \
-                "39-import-users.yml"
-        elif [ "${authtype}" == "jdbc" ]
-        then
-            ansible-playbook \
-                --inventory "${inventory:?}" \
-                --extra-vars "users_import_file=auth.sql" \
-                "39-import-users.yml"
-        else
-            ansible-playbook \
-                --inventory "${inventory:?}" \
-                "40-create-shiro-file.yml"
-        fi
-
-
-    popd
+    # Create user scripts and import users
 
     pushd "${treetop:?}/hadoop-yarn/ansible"
 
@@ -102,6 +78,26 @@
                 --inventory "${inventory:?}" \
                 "39-create-user-scripts.yml"
         fi
+
+        cat "/tmp/users.yml" | while read line
+        do
+          ssh -t zeppelin /home/fedora/zeppelin-0.10.0-bin-all/bin/add_user.sh line
+        done
+
+    popd
+
+    # Create shiro config for prod if needed
+
+    pushd "${treetop:?}/hadoop-yarn/ansible"
+
+
+        if [ "${authtype}" == "prod" ]
+        then
+            ansible-playbook \
+                --inventory "${inventory:?}" \
+                "40-create-shiro-file.yml"
+        fi
+
 
     popd
 

--- a/deployments/hadoop-yarn/bin/create-users.sh
+++ b/deployments/hadoop-yarn/bin/create-users.sh
@@ -63,9 +63,11 @@
                 --inventory "${inventory:?}" \
                 "38-install-user-db.yml"
         fi
+
+
     popd
 
-
+    source ${treetop:?}/hadoop-yarn/bin/restart-zeppelin.sh
 
     # Create user scripts and import users
 

--- a/notes/stv/20220509-hadoop-spark-impersonate-01.txt
+++ b/notes/stv/20220509-hadoop-spark-impersonate-01.txt
@@ -1,0 +1,89 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2022, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#  
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+
+Target:
+   Enable User impersonization for Zeppelin/Spark/Hadoop
+Result:
+   Success
+
+
+# -------------------------------------------
+# Set User Impersonate in Zeppelin
+
+# In Zeppelin UI, Modify Spark interpreter to
+
+The interpreter will be instantiated "Per User" in "isolated" process  
+[y] User Impersonate 
+
+
+# -----------------------------------------------------------------------------
+# Modify Hadoop configuration (core-site.xml), allow proxy users through fedora
+# Apply changes to all nodes (hadoop & zeppelin)
+
+nano /opt/hadoop/etc/hadoop/core-site.xml
+...
+
+<property>
+<name>hadoop.proxyuser.fedora.hosts</name>
+<value>*</value>
+</property>
+<property>
+<name>hadoop.proxyuser.fedora.groups</name>
+<value>*</value>
+</property>
+<property>
+<name>hadoop.proxyuser.fedora.users</name>
+<value>*</value>
+</property>
+
+...
+
+
+# Restart hdfs..
+
+
+# -----------------------------------------------------------------------------
+# Create HDFS directory for new user, and set permission
+# Otherwise we get a permission denied error as Spark tries to write to /user/ as the newuser but does not have permissions
+
+hdfs dfs -mkdir /user/gaiauser
+hdfs dfs -chown -R gaiauser:supergroup /user/gaiauser
+
+
+# Run Spark job [SUCCESS]
+
+
+# Repeat for another user
+
+
+
+hdfs dfs -mkdir /user/gaiadmp
+hdfs dfs -chown -R gaiadmp:supergroup /user/gaiadmp
+
+# Run Spark job [SUCCESS]
+
+
+# Check Hadoop UI
+
+# Two jobs started, one as "gaiauser" and one as "gaiadmp"
+# Both jobs started right away, and released resources after completion (except for 4% which they retain)
+

--- a/notes/stv/20220509-user-impersonate-sh-01.txt
+++ b/notes/stv/20220509-user-impersonate-sh-01.txt
@@ -1,0 +1,232 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2022, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#  
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+
+Target:
+   Enable User impersonization for Zeppelin sh interpreter
+Result:
+   Success
+
+
+
+# Links:
+# https://zeppelin.apache.org/docs/0.10.0/usage/interpreter/user_impersonation.html
+
+
+# What user is run by default?
+
+# New sh notebook..
+
+%sh
+whoami
+
+> fedora
+
+
+
+# Create user gaiadmp	
+
+adduser gaiadmp
+
+# Generate an ssh pair for both fedora, and the new user
+# ssh-keygen
+
+# Add fedora's public key to /home/gaiadmp/.ssh/authorized_keys
+
+
+
+# Set User Impersonat in Zeppelin UI:
+
+The interpreter will be instantiated "Per User"  in  "isolated" process  
+
+Check "User Impersonate"
+
+# Restart Interpreter
+
+
+%sh
+whoami
+
+org.apache.zeppelin.interpreter.InterpreterException: java.io.IOException: Fail to launch interpreter process:
+Interpreter download command: /etc/alternatives/jre/bin/java -Dfile.encoding=UTF-8 -Dlog4j.configuration=file:///home/fedora/zeppelin-0.10.0-bin-all/conf/log4j.properties -Dlog4j.configurationFile=file:///home/fedora/zeppelin-0.10.0-bin-all/conf/log4j2.properties -Dzeppelin.log.file=/home/fedora/zeppelin-0.10.0-bin-all/logs/zeppelin-interpreter-sh-gaiadmp-gaiadmp-fedora-iris-gaia-red-20220504-zeppelin.log -cp :/home/fedora/zeppelin-0.10.0-bin-all/interpreter/sh/*:::/home/fedora/zeppelin-0.10.0-bin-all/interpreter/zeppelin-interpreter-shaded-0.10.0.jar org.apache.zeppelin.interpreter.remote.RemoteInterpreterDownloader 10.10.1.172 42989 sh /home/fedora/zeppelin-0.10.0-bin-all/local-repo/sh
+[INFO] Interpreter launch command: ssh gaiadmp@localhost source /home/fedora/zeppelin-0.10.0-bin-all/conf/zeppelin-env.sh; /etc/alternatives/jre/bin/java -Dfile.encoding=UTF-8 -Dlog4j.configuration=file:///home/fedora/zeppelin-0.10.0-bin-all/conf/log4j.properties -Dlog4j.configurationFile=file:///home/fedora/zeppelin-0.10.0-bin-all/conf/log4j2.properties -Dzeppelin.log.file=/home/fedora/zeppelin-0.10.0-bin-all/logs/zeppelin-interpreter-sh-gaiadmp-gaiadmp-fedora-iris-gaia-red-20220504-zeppelin.log -Xmx1024m -cp :/home/fedora/zeppelin-0.10.0-bin-all/local-repo/sh/*:/home/fedora/zeppelin-0.10.0-bin-all/interpreter/sh/*:::/home/fedora/zeppelin-0.10.0-bin-all/interpreter/zeppelin-interpreter-shaded-0.10.0.jar org.apache.zeppelin.interpreter.remote.RemoteInterpreterServer 10.10.1.172 42989 sh-gaiadmp :
+bash: /home/fedora/zeppelin-0.10.0-bin-all/conf/zeppelin-env.sh: Permission denied
+Error: Could not find or load main class org.apache.zeppelin.interpreter.remote.RemoteInterpreterServer
+
+	at org.apache.zeppelin.interpreter.remote.RemoteInterpreter.open(RemoteInterpreter.java:129)
+	at org.apache.zeppelin.interpreter.remote.RemoteInterpreter.getFormType(RemoteInterpreter.java:271)
+	at org.apache.zeppelin.notebook.Paragraph.jobRun(Paragraph.java:440)
+	at org.apache.zeppelin.notebook.Paragraph.jobRun(Paragraph.java:71)
+	at org.apache.zeppelin.scheduler.Job.run(Job.java:172)
+	at org.apache.zeppelin.scheduler.AbstractScheduler.runJob(AbstractScheduler.java:132)
+	at org.apache.zeppelin.scheduler.RemoteScheduler$JobRunner.run(RemoteScheduler.java:182)
+	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
+	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
+	at java.lang.Thread.run(Thread.java:748)
+Caused by: java.io.IOException: Fail to launch interpreter process:
+Interpreter download command: /etc/alternatives/jre/bin/java -Dfile.encoding=UTF-8 -Dlog4j.configuration=file:///home/fedora/zeppelin-0.10.0-bin-all/conf/log4j.properties -Dlog4j.configurationFile=file:///home/fedora/zeppelin-0.10.0-bin-all/conf/log4j2.properties -Dzeppelin.log.file=/home/fedora/zeppelin-0.10.0-bin-all/logs/zeppelin-interpreter-sh-gaiadmp-gaiadmp-fedora-iris-gaia-red-20220504-zeppelin.log -cp :/home/fedora/zeppelin-0.10.0-bin-all/interpreter/sh/*:::/home/fedora/zeppelin-0.10.0-bin-all/interpreter/zeppelin-interpreter-shaded-0.10.0.jar org.apache.zeppelin.interpreter.remote.RemoteInterpreterDownloader 10.10.1.172 42989 sh /home/fedora/zeppelin-0.10.0-bin-all/local-repo/sh
+[INFO] Interpreter launch command: ssh gaiadmp@localhost source /home/fedora/zeppelin-0.10.0-bin-all/conf/zeppelin-env.sh; /etc/alternatives/jre/bin/java -Dfile.encoding=UTF-8 -Dlog4j.configuration=file:///home/fedora/zeppelin-0.10.0-bin-all/conf/log4j.properties -Dlog4j.configurationFile=file:///home/fedora/zeppelin-0.10.0-bin-all/conf/log4j2.properties -Dzeppelin.log.file=/home/fedora/zeppelin-0.10.0-bin-all/logs/zeppelin-interpreter-sh-gaiadmp-gaiadmp-fedora-iris-gaia-red-20220504-zeppelin.log -Xmx1024m -cp :/home/fedora/zeppelin-0.10.0-bin-all/local-repo/sh/*:/home/fedora/zeppelin-0.10.0-bin-all/interpreter/sh/*:::/home/fedora/zeppelin-0.10.0-bin-all/interpreter/zeppelin-interpreter-shaded-0.10.0.jar org.apache.zeppelin.interpreter.remote.RemoteInterpreterServer 10.10.1.172 42989 sh-gaiadmp :
+bash: /home/fedora/zeppelin-0.10.0-bin-all/conf/zeppelin-env.sh: Permission denied
+Error: Could not find or load main class org.apache.zeppelin.interpreter.remote.RemoteInterpreterServer
+
+	at org.apache.zeppelin.interpreter.remote.ExecRemoteInterpreterProcess.start(ExecRemoteInterpreterProcess.java:97)
+	at org.apache.zeppelin.interpreter.ManagedInterpreterGroup.getOrCreateInterpreterProcess(ManagedInterpreterGroup.java:68)
+	at org.apache.zeppelin.interpreter.remote.RemoteInterpreter.getOrCreateInterpreterProcess(RemoteInterpreter.java:104)
+	at org.apache.zeppelin.interpreter.remote.RemoteInterpreter.internal_create(RemoteInterpreter.java:154)
+	at org.apache.zeppelin.interpreter.remote.RemoteInterpreter.open(RemoteInterpreter.java:126)
+
+	... 13 more
+
+
+
+# Create zeppelinusers group, and add fedora and new user to it
+
+  groupadd zeppelinusers
+  usermod -a -G zeppelinusers gaiadmp
+  usermod -a -G zeppelinusers fedora
+
+
+# Change permissions of fedora/zeppelin folders
+
+  sudo chmod 750 fedora/
+  sudo chmod 750 -R fedora/zeppelin-0.10.0-bin-all/
+  sudo chown -R fedora:zeppelinusers fedora/
+ 
+
+# Set home directory to each user's
+
+# Open sh interpreter in Zeppelin UI
+
+Set:
+ shell.working.directory.user.home	true
+
+
+	
+# Restart Zeppelin
+
+/home/fedora/zeppelin-0.10.0-bin-all/bin/zeppelin-daemon.sh restart
+
+
+
+# New sh notebook..
+
+%sh
+whoami
+
+> gaiadmp
+
+
+%sh
+whoami
+
+> /home/gaiadmp
+
+
+%sh
+ls /home/fedora/zeppelin-0.10.0-bin-all
+
+>
+
+bin
+conf
+interpreter
+k8s
+lib
+LICENSE
+licenses
+local-repo
+logs
+notebook
+notebook2
+NOTICE
+plugins
+README.md
+run
+scripts
+spark-warehouse
+webapps
+zeppelin-web-0.10.0.war
+zeppelin-web-angular-0.10.0.war
+
+
+%sh
+cat /home/fedora/zeppelin-0.10.0-bin-all/conf/shiro.ini
+
+# Shows full shiro.ini file
+# Not good, so any user would have access to zeppelin configuration files and thus credentials to our local SQL database
+
+# So summary so far, user impersonate works, but only if the user has read/execute access to the zeppelin configuration & parent directory data (i.e. /fedora/..)
+
+
+# Let's try restricting the permission of sensitive files
+
+
+%sh
+cat /home/fedora/zeppelin-0.10.0-bin-all/conf/shiro.ini
+
+> .. Permission Denied
+
+
+
+
+
+# After some experimentation, it seems like the following is the minimum amount of permissions we need to give "zeppelin users"
+
+sudo chown fedora:zeppelinusers /home/fedora/
+sudo chown fedora:zeppelinusers /home/fedora/zeppelin-0.10.0-bin-all
+sudo chown -R fedora:zeppelinusers /home/fedora/zeppelin-0.10.0-bin-all/interpreter
+sudo chown fedora:zeppelinusers /home/fedora/zeppelin-0.10.0-bin-all/conf
+sudo chown fedora:zeppelinusers /home/fedora/zeppelin-0.10.0-bin-all/conf/zeppelin-env.sh
+
+
+
+
+# New sh notebook..
+
+%sh
+whoami
+
+> gaiadmp
+	
+# With this setup, Zeppelin users can ls to see what folders/files exist under /zeppelin-0.10.0-bin-all and under /zeppelin-0.10.0-bin-all/conf, but they can only access the zeppelin-env.sh file.
+
+
+
+
+# Add local pub key to new user's authorized_keys, and check if we can login from local machine
+
+
+%sh
+echo "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC3T5ShHZ+HQJ6LpPwgpqRK/U0SYnGLSGY7LtwPiDA4TM2PWIbrV1HdcScV4GpbvDZLsA9e1Uh6MtjHjOSvUxgn++XhcfH4WZS+I2zxN56MeU2gONITlC12Fr1CQtnwix8H30qY/8m4wiiZIE0LC5qqWM5dVq0lwWl6iyZj7hH9O+gdm34HFZaLOno1f49r6VkXEWGT6/YQdqfHbG9EpOrNYEeGsDx3DBZt3PF9IU2FZrSpogM99UOxm8Fhnn0WaVaS56BrIZs/X128L7IEgb0jEl0Z/iacp+Pn4itbj77i3Pr5H0N3Ir9jilTPe7K83k3QSzV+Os6KWrWc8m63QE03 stelios@stelios-pc" >> /home/gaiadmp/.ssh/authorized_keys
+
+
+ssh gaiadmp@128.232.222.144
+Last login: Mon May  9 12:51:39 2022 from 176.92.15.192
+[gaiadmp@iris-gaia-red-20220504-zeppelin ~]$ 
+
+# Success
+
+
+# In theory, we could now write the output of a dataframe to a localfile, and copy it out of Zeppelin to our local machine this way.

--- a/notes/stv/20220517-create-users-test.txt
+++ b/notes/stv/20220517-create-users-test.txt
@@ -1,0 +1,176 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2022, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+
+    Target:
+
+        Run Test Deploy, testing creation of new users using our scripts 
+        
+
+    Result:
+  
+        PASS 
+
+
+# -----------------------------------------------------
+# Fetch target branch
+#[user@desktop]
+
+    source "${HOME:?}/aglais.env"
+    pushd "${AGLAIS_CODE}"
+      	git checkout 'feature/user-impersonate'
+
+    popd
+
+
+# -----------------------------------------------------
+# Create a container to work with.
+#[user@desktop]
+
+    source "${HOME:?}/aglais.env"
+
+    podman run \
+        --rm \
+        --tty \
+        --interactive \
+        --name ansibler \
+        --hostname ansibler \
+        --publish 3000:3000 \
+        --publish 8088:8088 \
+        --env "SSH_AUTH_SOCK=/mnt/ssh_auth_sock" \
+        --volume "${SSH_AUTH_SOCK}:/mnt/ssh_auth_sock:rw,z" \
+        --volume "${HOME:?}/clouds.yaml:/etc/openstack/clouds.yaml:ro,z" \
+        --volume "${AGLAIS_CODE:?}/deployments:/deployments:ro,z" \
+        --volume "${AGLAIS_SECRETS:?}/users.yml:/tmp/users.yml:ro,z" \
+        atolmis/ansible-client:2021.08.25 \
+        bash
+
+
+# -----------------------------------------------------
+# Set the cloud and configuration.
+#[root@ansibler]
+
+    cloudname=iris-gaia-red
+
+    configname=zeppelin-26.43-spark-6.26.43
+
+
+# -----------------------------------------------------
+# Delete everything.
+#[root@ansibler]
+
+    time \
+        /deployments/openstack/bin/delete-all.sh \
+            "${cloudname:?}"
+
+
+# -----------------------------------------------------
+# Create everything, using the new config.
+#[root@ansibler]
+
+    time \
+        /deployments/hadoop-yarn/bin/create-all.sh \
+            "${cloudname:?}" \
+            "${configname:?}"   \
+        | tee /tmp/create-all.log
+
+
+        > Done
+
+
+# -----------------------------------------------------
+# Create ssh key for fedora (Zeppelin) user and known_hosts file
+#[root@ansibler]
+
+
+    ssh \
+        -t \
+        zeppelin \
+            "
+            sudo ssh-keygen -t rsa -N '' -f /home/fedora/.ssh/id_rsa
+            "
+
+    ssh \
+        -t \
+        zeppelin \
+            "
+            sudo chown fedora:fedora /home/fedora/.ssh/*
+            "
+    ssh \
+        -t \
+        zeppelin \
+            "
+            ssh-keyscan -H localhost >> /home/fedora/.ssh/known_hosts
+            "
+
+
+# -----------------------------------------------------
+# Clone notebook repository into Zeppelin
+#[root@ansibler]
+
+      ssh \
+        -t \
+        zeppelin \
+            "
+            rm -r  /home/fedora/zeppelin-0.10.0-bin-all/notebook
+            "
+
+      ssh \
+        -t \
+        zeppelin \
+            "
+            git clone https://github.com/wfau/aglais-notebooks /home/fedora/zeppelin-0.10.0-bin-all/notebook
+            "
+ 
+# -----------------------------------------------------
+# Restart Zeppelin
+#[root@ansibler]
+
+
+     time /deployments/hadoop-yarn/bin/restart-zeppelin.sh 
+
+
+# -----------------------------------------------------
+# Create (test) users.
+#[root@ansibler]
+
+    time \
+        /deployments/hadoop-yarn/bin/create-users.sh \
+            "${cloudname:?}" \
+            "${configname:?}"   \
+            "jdbc"   \
+        | tee /tmp/create-users.log
+
+# Note: For this deploy, I modified the add_user script that we create in Zeppelin/bin to include the DB_PASSWORD, as we don't yet have MariaDB enabled
+
+
+# -----------------------------------------------------
+# Test as "gaiauser"
+#[zeppelin GUI]
+
+# Login [SUCCESS]
+# Test Spark notebooks / Confirm that it is run as gaiauser in Yarn UI [SUCCESS]
+# Test sh notebooks / Confirm that it is run as gaiauser [SUCCESS]
+# Test python notebooks / Confirm that it is run as gaiauser [SUCCESS]
+
+
+
+

--- a/notes/stv/20220517-create-users-test.txt
+++ b/notes/stv/20220517-create-users-test.txt
@@ -172,5 +172,105 @@
 # Test python notebooks / Confirm that it is run as gaiauser [SUCCESS]
 
 
+# -------------------------------------------------------------------------------
+# Run Basic Test
+#
+#[root@ansibler]
 
 
+    cloudname=iris-gaia-red
+    configname=zeppelin-26.43-spark-6.26.43
+    num_users=1
+    concurrent=True
+    test_level="basic"
+
+
+    time \
+        /deployments/hadoop-yarn/bin/run-tests.sh \
+            "${cloudname:?}" \
+            "${configname:?}" \
+            "${test_level:?}"  \
+	     ${concurrent:?}  \
+	     ${num_users:?}  \
+        | tee /tmp/run-tests-basic.log	
+
+
+# Reults:
+
+[{
+	'GaiaDMPSetup': {
+		'result': 'PASS',
+		'outputs': {
+			'valid': True
+		},
+		'time': {
+			'result': 'FAST',
+			'elapsed': '35.75',
+			'expected': '45.00',
+			'percent': '-20.55',
+			'start': '2022-05-17T12:54:07.453545',
+			'finish': '2022-05-17T12:54:43.207929'
+		},
+		'logs': ''
+	},
+	'Mean_proper_motions_over_the_sky': {
+		'result': 'PASS',
+		'outputs': {
+			'valid': True
+		},
+		'time': {
+			'result': 'SLOW',
+			'elapsed': '70.13',
+			'expected': '55.00',
+			'percent': '27.51',
+			'start': '2022-05-17T12:54:43.208053',
+			'finish': '2022-05-17T12:55:53.339942'
+		},
+		'logs': ''
+	},
+	'Source_counts_over_the_sky.json': {
+		'result': 'PASS',
+		'outputs': {
+			'valid': True
+		},
+		'time': {
+			'result': 'SLOW',
+			'elapsed': '32.47',
+			'expected': '22.00',
+			'percent': '47.59',
+			'start': '2022-05-17T12:55:53.340181',
+			'finish': '2022-05-17T12:56:25.809983'
+		},
+		'logs': ''
+	},
+	'Good_astrometric_solutions_via_ML_Random_Forrest_classifier': {
+		'result': 'PASS',
+		'outputs': {
+			'valid': True
+		},
+		'time': {
+			'result': 'SLOW',
+			'elapsed': '590.59',
+			'expected': '500.00',
+			'percent': '18.12',
+			'start': '2022-05-17T12:56:25.810321',
+			'finish': '2022-05-17T13:06:16.403069'
+		},
+		'logs': ''
+	},
+	'Library_Validation.json': {
+		'result': 'PASS',
+		'outputs': {
+			'valid': True
+		},
+		'time': {
+			'result': 'FAST',
+			'elapsed': '8.82',
+			'expected': '60.00',
+			'percent': '-85.30',
+			'start': '2022-05-17T13:06:16.403250',
+			'finish': '2022-05-17T13:06:25.224187'
+		},
+		'logs': ''
+	}
+}]


### PR DESCRIPTION
Changes to enable user-impersonation.
Spark / Python & sh are now started as the user, rather than "fedora".

Additional changes include changes to how new users are added. We now use the add_user script that we create under zeppelin/bin when creating the initial list of known users.