### PR TITLE
Add Nginx proxy & Enable HTTPS (Lets Encrypt) on our Ansible deploy

### DIFF
--- a/deployments/hadoop-yarn/ansible/25-create-zeppelin.yml
+++ b/deployments/hadoop-yarn/ansible/25-create-zeppelin.yml
@@ -62,7 +62,7 @@
         port_range_max: 22
         remote_ip_prefix: '::/0'
 
-    - name: "Add a security rule for IPv4 Port 8080"
+    - name: "Add a security rule for IPv4 Port 80"
       os_security_group_rule:
         cloud: "{{ cloudname }}"
         state: present
@@ -70,11 +70,11 @@
         direction: 'ingress'
         protocol:  'tcp'
         ethertype: 'IPv4'
-        port_range_min: 8080
-        port_range_max: 8080
+        port_range_min: 80
+        port_range_max: 80
         remote_ip_prefix: '0.0.0.0/0'
 
-    - name: "Add a security rule for IPv6 Port 8080"
+    - name: "Add a security rule for IPv6 Port 80"
       os_security_group_rule:
         cloud: "{{ cloudname }}"
         state: present
@@ -82,8 +82,32 @@
         direction: 'ingress'
         protocol:  'tcp'
         ethertype: 'IPv6'
-        port_range_min: 8080
-        port_range_max: 8080
+        port_range_min: 80
+        port_range_max: 80
+        remote_ip_prefix: '::/0'
+
+    - name: "Add a security rule for IPv4 Port 443"
+      os_security_group_rule:
+        cloud: "{{ cloudname }}"
+        state: present
+        security_group: "{{ zeppelinsec.id }}"
+        direction: 'ingress'
+        protocol:  'tcp'
+        ethertype: 'IPv4'
+        port_range_min: 443 
+        port_range_max: 443 
+        remote_ip_prefix: '0.0.0.0/0'
+
+    - name: "Add a security rule for IPv6 Port 443"
+      os_security_group_rule:
+        cloud: "{{ cloudname }}"
+        state: present
+        security_group: "{{ zeppelinsec.id }}"
+        direction: 'ingress'
+        protocol:  'tcp'
+        ethertype: 'IPv6'
+        port_range_min: 443  
+        port_range_max: 443 
         remote_ip_prefix: '::/0'
 
     - name: "Create our Zeppelin node"

--- a/deployments/hadoop-yarn/ansible/30-zeppelin-security.yml
+++ b/deployments/hadoop-yarn/ansible/30-zeppelin-security.yml
@@ -42,6 +42,28 @@
         port_range_max: 8080
         remote_group: "{{ security['zeppelin'] }}"
 
+    - name: "Allow zeppelin:80"
+      os_security_group_rule:
+        cloud: "{{ cloudname }}"
+        state: present
+        security_group: "{{ security['zeppelin'] }}"
+        direction: 'ingress'
+        protocol:  'tcp'
+        port_range_min: 80
+        port_range_max: 80
+        remote_group: "{{ security['zeppelin'] }}"
+
+    - name: "Allow zeppelin:443"
+      os_security_group_rule:
+        cloud: "{{ cloudname }}"
+        state: present
+        security_group: "{{ security['zeppelin'] }}"
+        direction: 'ingress'
+        protocol:  'tcp'
+        port_range_min: 443
+        port_range_max: 443
+        remote_group: "{{ security['zeppelin'] }}"
+
     # Allow any from masters.
     - name: "Allow any from masters to Zeppelin"
       os_security_group_rule:

--- a/deployments/hadoop-yarn/ansible/42-install-nginx.yml
+++ b/deployments/hadoop-yarn/ansible/42-install-nginx.yml
@@ -47,5 +47,4 @@
         dest: "{{ nginx_config_dir }}/zeppelin.conf"
       vars:
         hostname: "{{aglais.status.deployment.hostname}}"
-        deploytype: "{{aglais.status.deployment.deploytype}}"
 

--- a/deployments/hadoop-yarn/ansible/42-install-nginx.yml
+++ b/deployments/hadoop-yarn/ansible/42-install-nginx.yml
@@ -1,0 +1,51 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2021, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+
+- name: "Install NGINX Proxy"
+  hosts: zeppelin
+  gather_facts: false
+  vars_files:
+    - config/ansible.yml
+    - /tmp/ansible-vars.yml
+  vars:
+    nginx_config_dir: "/etc/nginx/conf.d/"
+  tasks:
+    - name: "Allow SELinux httpd to make network connections."
+      become: true
+      command: "setsebool -P httpd_can_network_connect 1"
+
+    - name: "Install NGINX using Yum"
+      become: true
+      yum:
+        name: nginx
+        update_cache: yes
+        state: present
+
+    - name: "Generate NGINX configuration"
+      become: true
+      template:
+        src:  "templates/nginx.j2"
+        dest: "{{ nginx_config_dir }}/zeppelin.conf"
+      vars:
+        hostname: "{{aglais.status.deployment.hostname}}"
+        deploytype: "{{aglais.status.deployment.deploytype}}"
+

--- a/deployments/hadoop-yarn/ansible/43-setup-ssl.yml
+++ b/deployments/hadoop-yarn/ansible/43-setup-ssl.yml
@@ -1,0 +1,99 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2021, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+
+- name: "Setup SSL for NGINX proxy"
+  hosts: zeppelin
+  gather_facts: false
+  vars_files:
+    - config/ansible.yml
+    - /tmp/ansible-vars.yml
+  vars:
+    nginx_config_dir: "/etc/nginx/conf.d/"
+  tasks:
+    - name: "Install certbot using Yum"   
+      become: true
+      yum:
+        name: 
+          - certbot
+          - python3-certbot-nginx
+        update_cache: yes
+        state: present
+
+    - name: "Install Cron"
+      become: true
+      yum:
+        name: 
+          - cronie 
+          - cronie-anacron
+        update_cache: yes
+        state: present
+
+    - name: "Generate NGINX configuration"
+      become: true
+      template:
+        src:  "templates/nginx-ssl.j2"
+        dest: "{{ nginx_config_dir }}/zeppelin.conf"
+      vars:
+        hostname: "{{aglais.status.deployment.hostname}}"
+
+    - name: "Make sure certificate destination dir exists"
+      become: true
+      file:
+        path: "/etc/letsencrypt/live/{{aglais.status.deployment.hostname}}"
+        state: directory
+
+    - name: "Copy Certificates into Zeppelin"
+      become: true
+      copy:
+        src: "{{ lookup('env','HOME') }}/certs/fullchain.pem"
+        dest: "/etc/letsencrypt/live/{{aglais.status.deployment.hostname}}/fullchain.pem"
+
+    - name: "Copy Certificates into Zeppelin"
+      become: true
+      copy:
+        src: "{{ lookup('env','HOME') }}/certs/privkey.pem"
+        dest: "/etc/letsencrypt/live/{{aglais.status.deployment.hostname}}/privkey.pem"
+
+    - name: "Copy options-ssl-nginx.conf into Zeppelin"
+      become: true
+      copy:
+        src: "{{ lookup('env','HOME') }}/certs/options-ssl-nginx.conf"
+        dest: "/etc/letsencrypt/options-ssl-nginx.conf"
+
+    - name: "Copy ssl-dhparams.pem into Zeppelin"
+      become: true
+      copy:
+        src: "{{ lookup('env','HOME') }}/certs/ssl-dhparams.pem"
+        dest: "/etc/letsencrypt/ssl-dhparams.pem"
+
+    - name: "Restart NGINX"
+      service:
+        name: nginx
+        state: restarted
+      become: yes
+
+    - name: "Create Cronjob to renew certificate"
+      ansible.builtin.cron:
+        name: "Renew Certificate with certbot at 4:10 everyday"
+        minute: "10"
+        hour: "4"
+        job: "sudo certbot renew --quiet"

--- a/deployments/hadoop-yarn/ansible/43-setup-ssl.yml
+++ b/deployments/hadoop-yarn/ansible/43-setup-ssl.yml
@@ -55,35 +55,12 @@
       vars:
         hostname: "{{aglais.status.deployment.hostname}}"
 
-    - name: "Make sure certificate destination dir exists"
+    - name: "Copy Certificates to Zeppelin"
       become: true
-      file:
-        path: "/etc/letsencrypt/live/{{aglais.status.deployment.hostname}}"
-        state: directory
-
-    - name: "Copy Certificates into Zeppelin"
-      become: true
-      copy:
-        src: "{{ lookup('env','HOME') }}/certs/fullchain.pem"
-        dest: "/etc/letsencrypt/live/{{aglais.status.deployment.hostname}}/fullchain.pem"
-
-    - name: "Copy Certificates into Zeppelin"
-      become: true
-      copy:
-        src: "{{ lookup('env','HOME') }}/certs/privkey.pem"
-        dest: "/etc/letsencrypt/live/{{aglais.status.deployment.hostname}}/privkey.pem"
-
-    - name: "Copy options-ssl-nginx.conf into Zeppelin"
-      become: true
-      copy:
-        src: "{{ lookup('env','HOME') }}/certs/options-ssl-nginx.conf"
-        dest: "/etc/letsencrypt/options-ssl-nginx.conf"
-
-    - name: "Copy ssl-dhparams.pem into Zeppelin"
-      become: true
-      copy:
-        src: "{{ lookup('env','HOME') }}/certs/ssl-dhparams.pem"
-        dest: "/etc/letsencrypt/ssl-dhparams.pem"
+      ansible.builtin.unarchive:
+        src: "{{ lookup('env','HOME') }}/certs/certs.tar.gz"
+        dest: "/etc/"
+        owner: root
 
     - name: "Restart NGINX"
       service:

--- a/deployments/hadoop-yarn/ansible/config/zeppelin-26.43-spark-3.26.43.yml
+++ b/deployments/hadoop-yarn/ansible/config/zeppelin-26.43-spark-3.26.43.yml
@@ -1,0 +1,188 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2020, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+#
+
+all:
+
+    vars:
+
+        # VM image
+        baseimage: 'Fedora-31-1.9'
+
+        # Flavor sizes
+        zeppelinflavor: 'gaia.vm.cclake.26vcpu'
+        masterflavor:   'gaia.vm.cclake.2vcpu'
+        workerflavor:   'gaia.vm.cclake.26vcpu'
+        monitorflavor:  'gaia.vm.cclake.2vcpu'
+
+        # Flavour values
+        zeppelinmemory: 88064
+        zeppelincores:  54
+
+        workermemory: 44032
+        workercores:  26
+        workercount:  3
+
+        # Calculated limits
+        spminmem: 1024
+        spmaxmem: "{{workermemory - 1024}}"
+
+        spmincores: 1
+        spmaxcores: "{{workercores}}"
+
+        sparkconfig: |
+
+            # https://spark.apache.org/docs/latest/configuration.html
+            # https://spark.apache.org/docs/latest/running-on-yarn.html
+            # https://stackoverflow.com/questions/37871194/how-to-tune-spark-executor-number-cores-and-executor-memory
+
+            spark.master                 yarn
+
+            # Spark config settings calculated using Cheatsheet.xlsx
+            # https://www.c2fo.io/img/apache-spark-config-cheatsheet/C2FO-Spark-Config-Cheatsheet.xlsx
+
+            # https://www.c2fo.io/c2fo/spark/aws/emr/2016/07/06/apache-spark-config-cheatsheet/
+            # https://github.com/AndresNamm/SparkDebugging/tree/master/ExecutorSizing
+
+            # Calculated using Cheatsheet.xlsx
+            spark.driver.memory                 58982m
+            spark.driver.memoryOverhead           9216
+            spark.driver.cores                       5
+            spark.driver.maxResultSize          40960m
+
+            spark.executor.memory                7168m
+            spark.executor.memoryOverhead         1024
+            spark.executor.cores                     5
+            #spark.executor.instances               30
+
+            spark.default.parallelism              300
+            #spark.sql.shuffle.partitions          300
+
+            # YARN Application Master settings
+            spark.yarn.am.memory                 2048m
+            spark.yarn.am.cores                      1
+
+            spark.dynamicAllocation.enabled          true
+            spark.shuffle.service.enabled            true
+            spark.dynamicAllocation.minExecutors      1
+             # spark.executor.instances from Cheatsheet
+            spark.dynamicAllocation.maxExecutors     30
+             # maxExecutors / 2
+            spark.dynamicAllocation.initialExecutors          15
+            spark.dynamicAllocation.cachedExecutorIdleTimeout 60s
+            spark.dynamicAllocation.executorIdleTimeout       60s
+            spark.sql.execution.arrow.pyspark.enabled            true
+    hosts:
+
+        zeppelin:
+            login:  'fedora'
+            image:  "{{baseimage}}"
+            flavor: "{{zeppelinflavor}}"
+            discs:
+              - type: 'local'
+                format: 'ext4'
+                mntpath: "/mnt/local/vdb"
+                devname: 'vdb'
+              - type: 'cinder'
+                size: 1024
+                format: 'btrfs'
+                mntpath: "/mnt/cinder/vdc"
+                devname: 'vdc'
+            paths:
+                # Empty on Zeppelin
+                hddatalink: "/var/hadoop/data"
+                hddatadest: "/mnt/local/vdb/hadoop/data"
+                # Empty on Zeppelin
+                hdtemplink: "/var/hadoop/temp"
+                hdtempdest: "/mnt/local/vdb/hadoop/temp"
+                # Empty on Zeppelin
+                hdlogslink: "/var/hadoop/logs"
+                hdlogsdest: "/mnt/local/vdb/hadoop/logs"
+                # Used on Zeppelin
+                sptemplink: "/var/spark/temp"
+                sptempdest: "/mnt/cinder/vdc/spark/temp"
+
+        monitor:
+            login:  'fedora'
+            image:  "{{baseimage}}"
+            flavor: "{{monitorflavor}}"
+            discs: []
+
+    children:
+
+        masters:
+            hosts:
+                master[01:01]:
+            vars:
+                login:  'fedora'
+                image:  "{{baseimage}}"
+                flavor: "{{masterflavor}}"
+                discs: []
+                paths:
+                    # Empty on master
+                    hddatalink: "/var/hadoop/data"
+                    hddatadest: "/mnt/local/vda/hadoop/data"
+                    # Used on master
+                    # /var/hadoop/temp/dfs/namesecondary/current/
+                    hdtemplink: "/var/hadoop/temp"
+                    hdtempdest: "/mnt/local/vda/hadoop/temp"
+                    # Used on master
+                    hdlogslink: "/var/hadoop/logs"
+                    hdlogsdest: "/mnt/local/vda/hadoop/logs"
+                    # Used on master
+                    # /var/hdfs/meta/namenode/fsimage/current/
+                    hdfsmetalink: "/var/hdfs/meta"
+                    hdfsmetadest: "/mnt/local/vda/hadoop/meta"
+
+        workers:
+            hosts:
+                worker[01:03]:
+            vars:
+                login:  'fedora'
+                image:  "{{baseimage}}"
+                flavor: "{{workerflavor}}"
+                discs:
+                  - type: 'local'
+                    format: 'ext4'
+                    mntpath: "/mnt/local/vdb"
+                    devname: 'vdb'
+                  - type: 'cinder'
+                    size: 1024
+                    format: 'btrfs'
+                    mntpath: "/mnt/cinder/vdc"
+                    devname: 'vdc'
+                paths:
+                    # Used on workers
+                    hddatalink: "/var/hadoop/data"
+                    hddatadest: "/mnt/local/vdb/hadoop/data"
+                    # Used on workers
+                    # /var/hadoop/temp/nm-local-dir/
+                    hdtemplink: "/var/hadoop/temp"
+                    hdtempdest: "/mnt/local/vdb/hadoop/temp"
+                    # Used on workers
+                    hdlogslink: "/var/hadoop/logs"
+                    hdlogsdest: "/mnt/local/vdb/hadoop/logs"
+                    # Empty on workers
+                    hdfslogslink: "/var/hdfs/logs"
+                    hdfslogsdest: "/mnt/local/vdb/hdfs/logs"
+                    # Empty on workers
+                    hdfsdatalink: "/var/hdfs/data"
+                    hdfsdatadest: "/mnt/cinder/vdc/hdfs/data"

--- a/deployments/hadoop-yarn/ansible/create-all.yml
+++ b/deployments/hadoop-yarn/ansible/create-all.yml
@@ -70,4 +70,4 @@
 - import_playbook: 30-zeppelin-security.yml
 - import_playbook: 32-monitor-security.yml
 - import_playbook: 33-install-prometheus.yml
-
+- import_playbook: 42-install-nginx.yml

--- a/deployments/hadoop-yarn/ansible/templates/nginx-ssl.j2
+++ b/deployments/hadoop-yarn/ansible/templates/nginx-ssl.j2
@@ -1,0 +1,57 @@
+
+# Zeppelin Website
+
+server {
+
+    server_name {{ hostname }};             
+
+    location / {    # For regular websever support
+            proxy_pass http://zeppelin:8080/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+
+            client_max_body_size       10m;
+            client_body_buffer_size    128k;
+
+            proxy_connect_timeout      90;
+            proxy_send_timeout         90;
+            proxy_read_timeout         90;
+
+            proxy_buffer_size          4k;
+            proxy_buffers              4 32k;
+            proxy_busy_buffers_size    64k;
+            proxy_temp_file_write_size 64k;
+    }
+
+    location /ws {  # For websocket support
+            proxy_pass http://zeppelin:8080/ws;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade websocket;
+            proxy_set_header Connection upgrade;
+            proxy_read_timeout 86400;
+    }
+
+    listen 443 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/{{ hostname }}/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/{{ hostname }}/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+}
+
+
+server {
+    if ($host = {{ hostname }}) {
+        return 301 https://$host$request_uri;
+    } # managed by Certbot
+
+
+    listen 80;
+    server_name {{ hostname }};
+    return 404; # managed by Certbot
+
+
+}

--- a/deployments/hadoop-yarn/ansible/templates/nginx.j2
+++ b/deployments/hadoop-yarn/ansible/templates/nginx.j2
@@ -1,0 +1,39 @@
+
+# Zeppelin Website
+
+server {
+
+    server_name {{ hostname }};             
+
+    location / {    # For regular websever support
+            proxy_pass http://zeppelin:8080/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+
+            client_max_body_size       10m;
+            client_body_buffer_size    128k;
+
+            proxy_connect_timeout      90;
+            proxy_send_timeout         90;
+            proxy_read_timeout         90;
+
+            proxy_buffer_size          4k;
+            proxy_buffers              4 32k;
+            proxy_busy_buffers_size    64k;
+            proxy_temp_file_write_size 64k;
+    }
+
+    location /ws {  # For websocket support
+            proxy_pass http://zeppelin:8080/ws;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade websocket;
+            proxy_set_header Connection upgrade;
+            proxy_read_timeout 86400;
+    }
+
+
+}
+

--- a/deployments/hadoop-yarn/bin/create-all.sh
+++ b/deployments/hadoop-yarn/bin/create-all.sh
@@ -46,6 +46,8 @@
     deployname="${cloudname:?}-$(date '+%Y%m%d')"
     deploydate=$(date '+%Y%m%dT%H%M%S')
 
+    hostname="${3:-zeppelin.gaia-dmp.uk}"
+
     configyml='/tmp/aglais-config.yml'
     statusyml='/tmp/aglais-status.yml'
     touch "${statusyml:?}"
@@ -68,6 +70,11 @@
     yq eval \
         --inplace \
         ".aglais.status.deployment.date = \"${deploydate}\"" \
+        "${statusyml:?}"
+
+    yq eval \
+        --inplace \
+        ".aglais.status.deployment.hostname = \"${hostname}\"" \
         "${statusyml:?}"
 
     yq eval \
@@ -101,6 +108,7 @@
     echo "---- ---- ----"
     echo "Deploy conf [${deployconf}]"
     echo "Deploy name [${deployname}]"
+    echo "Deploy hostname [${hostname}]"
     echo "Deploy date [${deploydate}]"
     echo "---- ---- ----"
 

--- a/deployments/hadoop-yarn/bin/setup-ssl.sh
+++ b/deployments/hadoop-yarn/bin/setup-ssl.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2022, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+#
+
+    set -eu
+    set -o pipefail
+
+    binfile="$(basename ${0})"
+    binpath="$(dirname $(readlink -f ${0}))"
+    treetop="$(dirname $(dirname ${binpath}))"
+
+    echo ""
+    echo "---- ---- ----"
+    echo "File [${binfile}]"
+    echo "Path [${binpath}]"
+    echo "Tree [${treetop}]"
+
+    cloudbase='arcus'
+    cloudname="${1:?}"
+    deployconf="${2:?}"
+
+    inventory="${treetop:?}/hadoop-yarn/ansible/config/${deployconf:?}.yml"
+
+    echo "---- ---- ----"
+    echo "Deploy conf [${deployconf}]"
+    echo "---- ---- ----"
+
+
+    # Setup SSL for nginx
+
+    pushd "/deployments/hadoop-yarn/ansible"
+
+        ansible-playbook \
+            --verbose \
+            --inventory "${inventory:?}" \
+            "38-nginx-ssl.yml"
+
+    popd
+
+
+
+# -----------------------------------------------------
+# Restart NGINX proxy
+
+    "${treetop:?}/hadoop-yarn/bin/start-nginx.sh"

--- a/deployments/hadoop-yarn/bin/setup-ssl.sh
+++ b/deployments/hadoop-yarn/bin/setup-ssl.sh
@@ -52,7 +52,7 @@
         ansible-playbook \
             --verbose \
             --inventory "${inventory:?}" \
-            "38-nginx-ssl.yml"
+            "43-setup-ssl.yml"
 
     popd
 

--- a/deployments/hadoop-yarn/bin/start-nginx.sh
+++ b/deployments/hadoop-yarn/bin/start-nginx.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2020, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+#
+
+
+# -----------------------------------------------------
+# Settings ...
+
+    binfile="$(basename ${0})"
+    binpath="$(dirname $(readlink -f ${0}))"
+    srcpath="$(dirname ${binpath})"
+
+    echo ""
+    echo "---- ---- ----"
+    echo "File [${binfile}]"
+    echo "Path [${binpath}]"
+
+# -----------------------------------------------------
+# Start the Zeppelin service.
+
+    echo ""
+    echo "---- ----"
+    echo "Starting NGINX"
+
+    ssh zeppelin \
+        '
+        sudo systemctl start nginx
+        '

--- a/notes/stv/20211102-NGINX-Proxy-with-https.txt
+++ b/notes/stv/20211102-NGINX-Proxy-with-https.txt
@@ -1,0 +1,315 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2021, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#  
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+#
+
+
+
+    Target:
+
+        Setup NGINX proxy for Zeppelin & Setup SSL for Zeppelin installation
+
+    Result:
+
+        SUCCESS
+
+# ---------------------------------------------
+# Get a Free Temporary domain name
+# https://www.noip.com/
+
+ > Created aglais.ddns.net
+
+
+# ---------------------------------------------
+# Update Yum
+# fedora@zeppelin
+
+sudo yum update
+ 
+
+# ---------------------------------------------
+# Install NGINX
+# fedora@zeppelin
+
+sudo yum install -y nginx
+
+
+# ---------------------------------------------
+# Setup NGINX Proxy Configuration for Zeppelin
+# fedora@zeppelin
+
+cat > "/etc/nginx/conf.d/zeppelin.conf" << EOF
+
+# Zeppelin Website
+
+server {
+    server_name aglais.ddns.net;            
+
+    location / {    # For regular websever support
+            proxy_pass http://zeppelin:8080/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+
+            client_max_body_size       10m;
+            client_body_buffer_size    128k;
+
+            proxy_connect_timeout      90;
+            proxy_send_timeout         90;
+            proxy_read_timeout         90;
+
+            proxy_buffer_size          4k;
+            proxy_buffers              4 32k;
+            proxy_busy_buffers_size    64k;
+            proxy_temp_file_write_size 64k;
+    }
+
+    location /ws {  # For websocket support
+            proxy_pass http://zeppelin:8080/ws;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade websocket;
+            proxy_set_header Connection upgrade;
+            proxy_read_timeout 86400;
+    }
+
+ 
+}
+
+EOF
+
+# ---------------------------------------------
+# Restart NGINX
+# fedora@zeppelin
+
+sudo nginx restart
+
+
+# ---------------------------------------------
+# Install certbot and nginx plugin
+# fedora@zeppelin
+
+sudo yum install -y certbot
+sudo yum install -y certbot python3-certbot-nginx
+
+
+# ---------------------------------------------
+# Run certbot to install certificate for Nginx
+# fedora@zeppelin
+ 
+
+sudo certbot --nginx
+
+Saving debug log to /var/log/letsencrypt/letsencrypt.log
+Plugins selected: Authenticator nginx, Installer nginx
+
+Which names would you like to activate HTTPS for?
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+1: aglais.ddns.net
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Select the appropriate numbers separated by commas and/or spaces, or leave input
+blank to select all options shown (Enter 'c' to cancel): 1
+Obtaining a new certificate
+Performing the following challenges:
+http-01 challenge for aglais.ddns.net
+Waiting for verification...
+Cleaning up challenges
+Deploying Certificate to VirtualHost /etc/nginx/conf.d/zeppelin.conf
+
+Please choose whether or not to redirect HTTP traffic to HTTPS, removing HTTP access.
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+1: No redirect - Make no further changes to the webserver configuration.
+2: Redirect - Make all requests redirect to secure HTTPS access. Choose this for
+new sites, or if you're confident your site works on HTTPS. You can undo this
+change by editing your web server's configuration.
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Select the appropriate number [1-2] then [enter] (press 'c' to cancel): 2
+Redirecting all traffic on port 80 to ssl in /etc/nginx/conf.d/zeppelin.conf
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Congratulations! You have successfully enabled https://aglais.ddns.net
+
+You should test your configuration at:
+https://www.ssllabs.com/ssltest/analyze.html?d=aglais.ddns.net
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+IMPORTANT NOTES:
+ - Congratulations! Your certificate and chain have been saved at:
+   /etc/letsencrypt/live/aglais.ddns.net/fullchain.pem
+   Your key file has been saved at:
+   /etc/letsencrypt/live/aglais.ddns.net/privkey.pem
+   Your cert will expire on 2022-01-31. To obtain a new or tweaked
+   version of this certificate in the future, simply run certbot again
+   with the "certonly" option. To non-interactively renew *all* of
+   your certificates, run "certbot renew"
+ - If you like Certbot, please consider supporting our work by:
+
+   Donating to ISRG / Let's Encrypt:   https://letsencrypt.org/donate
+   Donating to EFF:                    https://eff.org/donate-le
+
+
+# --------------------------------
+# Reload NGINX 
+# fedora@zeppelin
+
+sudo nginx -s reload
+
+
+# --------------------------------
+# Access Zeppelin UI 
+# user@desktop
+
+firefox https://aglais.ddns.net
+
+# [SUCCESS]
+
+
+# --------------------------------
+# Run a Notebook: 
+# user@desktop
+
+# https://aglais.ddns.net/#/notebook/2GJ2NK5K7
+
+# [SUCCESS]
+
+
+# --------------------------------
+# Check what our NGINX configuration looks like after running the cerbot certificate generation
+# fedora@zeppelin
+
+
+cat /etc/nginx/conf.d/zeppelin.conf
+
+
+# Zeppelin Website
+
+server {
+
+    server_name aglais.ddns.net;             
+
+    location / {    # For regular websever support
+            proxy_pass http://zeppelin:8080/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+
+            client_max_body_size       10m;
+            client_body_buffer_size    128k;
+
+            proxy_connect_timeout      90;
+            proxy_send_timeout         90;
+            proxy_read_timeout         90;
+
+            proxy_buffer_size          4k;
+            proxy_buffers              4 32k;
+            proxy_busy_buffers_size    64k;
+            proxy_temp_file_write_size 64k;
+    }
+
+    location /ws {  # For websocket support
+            proxy_pass http://zeppelin:8080/ws;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade websocket;
+            proxy_set_header Connection upgrade;
+            proxy_read_timeout 86400;
+    }
+
+    listen 443 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/aglais.ddns.net/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/aglais.ddns.net/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+}
+
+server {
+    if ($host = aglais.ddns.net) {
+        return 301 https://$host$request_uri;
+    } # managed by Certbot
+
+
+    listen 80;
+    server_name aglais.ddns.net;
+    return 404; # managed by Certbot
+
+
+}
+
+
+
+# -----------------------------------------
+# Renewing Let's Encrypt Certificate
+# fedora@zeppelin
+
+sudo certbot renew --post-hook "nginx -s reload"
+
+     > 
+	Saving debug log to /var/log/letsencrypt/letsencrypt.log
+
+	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	Processing /etc/letsencrypt/renewal/aglais.ddns.net.conf
+	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	Cert not yet due for renewal
+
+	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+	The following certs are not due for renewal yet:
+	  /etc/letsencrypt/live/aglais.ddns.net/fullchain.pem expires on 2022-01-31 (skipped)
+	No renewals were attempted.
+	No hooks were run.
+	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+
+
+# -----------------------------------------
+# Setup as cronjob
+# fedora@zeppelin
+
+# Install cron
+sudo yum install cronie cronie-anacron
+
+
+# Create cronjob
+EDITOR=nano crontab -e
+no crontab for fedora - using an empty one
+crontab: installing new crontab
+
+..
+10 4 * * *   sudo certbot renew --quiet
+..
+
+
+# Check cronjob
+crontab -l
+10 4 * * *   sudo certbot renew --quiet
+
+
+
+# Next steps.. Work on adding this to the Ansible scripts
+# But.. I'm guessing we don't/can't regenerate new certifates each time we deploy
+# So we need to figure out how to store the certificates and re-use them when we redeploy
+
+
+# For now fetch the certificates pairs to local files
+
+

--- a/notes/stv/20211106-NGINX-deployments.txt
+++ b/notes/stv/20211106-NGINX-deployments.txt
@@ -1,0 +1,198 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2021, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+
+    Target:
+
+        Test feature-515-https branch
+           Branch includes changes to install NGINX in Ansible deploy & optionally SSL
+           Test with SSL included / Test without SSL
+    Result:
+
+        SUCCESS
+
+# Description of experiment / branch:
+
+# In this version of the code, we use two additional parameters in the create script:
+#  - hostname: The dns name we are using for this installation
+#  - deploytype: The type of deploy this is (prod / dev / test)
+
+# If deploytype is set to prod, then the scripts also install an SSL certificate on the NGINX proxy
+
+# In this version of the code, we include the certificate files that certbot created when creating the certificate, under deployments/common/zeppelin/certs, so the scripts expect to find them there if deploytype is "prod"
+
+# In future versions, we probably want to mount/read those from somewhere in an automated way
+
+# One more thing to note, is that for this experiment I used a Free DDNS service (https://www.noip.com/). I setup a dns name (aglais.ddns.net), and each time I did a new deploy, I pointed the dns entry to the newly created IP of the Zeppelin node
+
+
+
+
+# -----------------------------------------------------
+# Checkout the deployment branch.
+#[user@desktop]
+
+    source "${HOME:?}/aglais.env"
+    pushd "${AGLAIS_CODE}"
+
+            git checkout 'feature-515-https'
+
+    popd
+
+
+# -----------------------------------------------------
+# Create a container to work with.
+#[user@desktop]
+
+    source "${HOME:?}/aglais.env"
+
+    AGLAIS_CLOUD=gaia-test
+
+    docker run \
+        --rm \
+        --tty \
+        --interactive \
+        --name ansibler \
+        --hostname ansibler \
+        --env "SSH_AUTH_SOCK=/mnt/ssh_auth_sock" \
+        --volume "${SSH_AUTH_SOCK}:/mnt/ssh_auth_sock:rw,z" \
+        --env "cloudname=${AGLAIS_CLOUD:?}" \
+        --volume "${HOME:?}/clouds.yaml:/etc/openstack/clouds.yaml:ro,z" \
+        --volume "${AGLAIS_CODE:?}/deployments:/deployments:ro,z" \
+        atolmis/ansible-client:2021.08.25 \
+        bash
+
+
+# -----------------------------------------------------
+# Delete everything.
+#[root@ansibler]
+
+    time \
+        /deployments/openstack/bin/delete-all.sh \
+            "${cloudname:?}"
+
+> Done
+
+
+# -----------------------------------------------------
+# Create everything, using the cclake-medium-04 config.
+#[root@ansibler]
+
+
+    time \
+        /deployments/hadoop-yarn/bin/create-all.sh \
+            "${cloudname:?}" \
+            'cclake-medium-04' \
+            'dev' \
+            'aglais.ddns.net'
+
+
+
+> real	41m37.127s
+> user	12m2.754s
+> sys	3m16.246s
+
+
+# -----------------------------------------------------
+# Try accessing Zeppelin at the given hostname: aglais.ddns.net
+#[user@local]
+
+firefox http://aglais.ddns.net
+
+> [SUCCESS] 
+
+
+
+
+
+
+# Now test out SSL secured version
+
+
+# -----------------------------------------------------
+# Create a container to work with.
+#[user@desktop]
+
+    source "${HOME:?}/aglais.env"
+
+    AGLAIS_CLOUD=gaia-test
+
+    docker run \
+        --rm \
+        --tty \
+        --interactive \
+        --name ansibler \
+        --hostname ansibler \
+        --env "SSH_AUTH_SOCK=/mnt/ssh_auth_sock" \
+        --volume "${SSH_AUTH_SOCK}:/mnt/ssh_auth_sock:rw,z" \
+        --env "cloudname=${AGLAIS_CLOUD:?}" \
+        --volume "${HOME:?}/clouds.yaml:/etc/openstack/clouds.yaml:ro,z" \
+        --volume "${AGLAIS_CODE:?}/deployments:/deployments:ro,z" \
+        atolmis/ansible-client:2021.08.25 \
+        bash
+
+
+
+# -----------------------------------------------------
+# Delete everything.
+#[root@ansibler]
+
+    time \
+        /deployments/openstack/bin/delete-all.sh \
+            "${cloudname:?}"
+
+
+> Done
+
+# -----------------------------------------------------
+# Create everything, using the cclake-medium-04 config.
+#[root@ansibler]
+
+
+    time \
+        /deployments/hadoop-yarn/bin/create-all.sh \
+            "${cloudname:?}" \
+            'cclake-medium-04' \
+            'prod' \
+            'aglais.ddns.net'
+
+
+
+> real	43m53.675s
+> user	10m1.838s
+> sys	2m40.699s
+
+# -----------------------------------------------------
+# Try accessing Zeppelin at the given hostname: aglais.ddns.net
+# Use 
+#[user@local]
+
+
+firefox https://aglais.ddns.net
+
+[SUCCESS]
+
+# Note: if we try with just http, we get redirected to the https page
+
+
+
+
+# Note: In both cases I ran some simple PySpark examples (pi calculation) to confirm that Spark and Zeppelin work ok

--- a/notes/stv/20220706-01-red-deploy-https.txt
+++ b/notes/stv/20220706-01-red-deploy-https.txt
@@ -1,0 +1,281 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2022, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+
+
+    Target:
+
+        Test deployment with NGINX proxy and HTTPS
+
+    Result:
+
+
+
+
+# -----------------------------------------------------
+# Create a container to work with.
+#[user@desktop]
+
+    source "${HOME:?}/aglais.env"
+
+    podman run \
+        --rm \
+        --tty \
+        --interactive \
+        --name ansibler \
+        --hostname ansibler \
+        --publish 3000:3000 \
+        --env "SSH_AUTH_SOCK=/mnt/ssh_auth_sock" \
+        --volume "${SSH_AUTH_SOCK}:/mnt/ssh_auth_sock:rw,z" \
+        --volume "${HOME:?}/clouds.yaml:/etc/openstack/clouds.yaml:ro,z" \
+        --volume "${AGLAIS_CODE:?}/deployments:/deployments:ro,z" \
+        ghcr.io/wfau/atolmis/ansible-client:2022.03.19 \
+        bash
+
+
+# -----------------------------------------------------
+# Set the target configuration.
+#[root@ansibler]
+
+    cloudbase='arcus'
+    cloudname='iris-gaia-red'
+    configname=zeppelin-26.43-spark-3.26.43
+
+
+# -----------------------------------------------------
+# Delete everything.
+#[root@ansibler]
+
+    time \
+        /deployments/openstack/bin/delete-all.sh \
+            "${cloudname:?}"
+
+    >  Done
+
+
+# -----------------------------------------------------
+# Add the ssh key for our data node.
+# This is used by the getpasshash function in the client container.
+#[root@ansibler]
+
+    ssh-keyscan 'data.aglais.uk' >> "${HOME}/.ssh/known_hosts"
+    
+
+
+# -----------------------------------------------------
+# Copy certificates from data server
+#[root@ansibler]
+
+    scp -r fedora@data.aglais.uk:/home/fedora/certs/ /root/
+
+
+# -----------------------------------------------------
+# Create everything.
+#[root@ansibler]
+
+    time \
+        /deployments/hadoop-yarn/bin/create-all.sh \
+            "${cloudname:?}" \
+            "${configname:?}" \
+            "aglais-dev.ddns.net" \
+        | tee /tmp/create-all.log
+
+    >  Done
+
+
+	---- ----
+	Restarting Zeppelin
+	Zeppelin stop                                              [  OK  ]
+	Zeppelin start                                             [  OK  ]
+
+	real	58m0.139s
+	user	12m47.399s
+	sys	2m10.045s
+
+
+# Update the dns entry
+# Note: DNS was setup with https://my.noip.com/
+# Check if we can access http://aglais-dev.ddns.net/
+
+# [Success]
+
+# -----------------------------------------------------
+# Enable HTTPS
+#[root@ansibler]
+
+    time \
+        /deployments/hadoop-yarn/bin/setup-ssl.sh \
+            "${cloudname:?}" \
+            "${configname:?}" \
+        | tee /tmp/setup-ssl.log
+
+        > Done
+ 
+# -----------------------------------------------------
+# Create our shiro-auth database.
+#[root@ansibler]
+
+    time \
+        /deployments/hadoop-yarn/bin/create-auth-database.sh \
+            "${cloudname:?}" \
+            "${configname:?}" \
+        | tee /tmp/create-auth-database.log
+
+        > Done
+
+
+
+# -----------------------------------------------------
+# Copy notebooks from the live server.
+#[root@ansibler]
+
+
+     ssh zeppelin \
+        '
+        sshuser=fedora
+        sshhost=data.aglais.uk
+
+        sudo mkdir -p '/var/local/backups'
+        sudo mv "/home/fedora/zeppelin/notebook" \
+           "/var/local/backups/notebook-$(date '+%Y%m%d%H%M%S')"
+
+
+        rsync \
+            --perms \
+            --times \
+            --group \
+            --owner \
+            --stats \
+            --progress \
+            --human-readable \
+            --checksum \
+            --recursive \
+            "${sshuser:?}@${sshhost:?}://var/local/backups/notebook/" \
+            "/home/fedora/zeppelin/notebook"
+        '
+        
+        > Done
+        
+        
+# Remove test notebook:
+  ssh zeppelin 'rm "/home/fedora/zeppelin/notebook/Untitled Note 1_2H3R2UM2V.zpln"'
+
+
+# -----------------------------------------------------
+# Restart Zeppelin
+#[root@ansibler]
+
+    ssh zeppelin \
+        '
+        zeppelin-daemon.sh restart
+        '
+        
+# -----------------------------------------------------
+# Get the public IP address of our Zeppelin node.
+#[root@ansibler]
+
+    cloudname=$(
+        yq eval \
+            '.aglais.spec.openstack.cloud.name' \
+            '/tmp/aglais-status.yml'
+        )
+
+    deployname=$(
+        yq eval \
+            '.aglais.status.deployment.name' \
+            '/tmp/aglais-status.yml'
+        )
+
+    zeppelinid=$(
+        openstack \
+            --os-cloud "${cloudname:?}" \
+            server list \
+                --format json \
+        | jq -r '.[] | select(.Name == "'${deployname:?}'-zeppelin") | .ID'
+        )
+
+    zeppelinip=$(
+        openstack \
+            --os-cloud "${cloudname:?}" \
+            server show \
+                --format json \
+                "${zeppelinid:?}" \
+        | jq -r ".addresses | .\"${deployname}-internal-network\" | .[1]"
+        )
+
+cat << EOF
+Zeppelin ID [${zeppelinid:?}]
+Zeppelin IP [${zeppelinip:?}]
+EOF
+
+  
+> Zeppelin ID [020ccced-dbbe-4d38-9787-addde3bb6af2]
+> Zeppelin IP [128.232.227.195]
+
+
+
+# -----------------------------------------------------
+# Delete users, so that we can recreate them
+    ssh zeppelin 'sudo userdel -r stv'
+    ssh zeppelin 'sudo userdel -r zrq'
+    ssh zeppelin 'sudo userdel -r nch'
+    ssh zeppelin 'sudo userdel -r dcr'
+	
+# -----------------------------------------------------
+# Create users
+
+source /deployments/zeppelin/bin/create-user-tools.sh
+
+createusermain \
+        "stv" "admin" \
+    | jq '.'
+    
+{
+  "linuxuser": {
+    "name": "stv",
+    "type": "admin",
+    "home": "/home/stv",
+    "uid": 20001
+  },
+  "shirouser": {
+    "name": "stv",
+    "type": "admin",
+    "pass": "",
+    "hash": ""
+  },
+  "hdfsspace": {
+    "path": "/albert/stv",
+    "owner": "stv",
+    "group": "supergroup"
+  },
+  "notebooks": {}
+}
+
+
+
+	
+# -----------------------------------------------------	
+# Test & Validate user login & Spark job via UI
+# Success
+
+# Test simple Spark notebook
+# Success
+

--- a/notes/stv/20220706-02-red-deploy-https-live.txt
+++ b/notes/stv/20220706-02-red-deploy-https-live.txt
@@ -152,16 +152,17 @@ Zeppelin IP [${zeppelinip:?}]
 EOF
 
   
-> Zeppelin ID [f19cce84-fc13-4e88-889d-3127d79dcc7d]
-> Zeppelin IP [128.232.227.158]
+> Zeppelin ID [a8e9afff-f4b3-49c1-9447-d89fc26c9312]
+> Zeppelin IP [128.232.227.195]
+
 
 
 # Update the dns entry with new IP
-# zeppelin.gaia-dmp.uk -> 128.232.227.158
+# zeppelin.gaia-dmp.uk -> 128.232.227.195
 
 ducktoken=[TOKEN_HERE]
 duckname=aglais-live
-zeppelinip=128.232.227.158
+zeppelinip=128.232.227.195
 curl "https://www.duckdns.org/update/${duckname:?}/${ducktoken:?}/${zeppelinip:?}"
 
 # [Success]
@@ -365,4 +366,13 @@ createusermain \
 
 # Test simple Spark notebook (Source Count)
 # Success
+
+
+# -----------------------------------------
+# Renewing Let's Encrypt Certificate
+# fedora@zeppelin
+
+sudo certbot renew --post-hook "nginx -s reload"
+
+> Failed
 

--- a/notes/stv/20220706-02-red-deploy-https-live.txt
+++ b/notes/stv/20220706-02-red-deploy-https-live.txt
@@ -1,0 +1,368 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2022, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+
+
+    Target:
+
+        Test deployment with NGINX proxy and HTTPS
+
+    Result:
+
+
+
+
+# -----------------------------------------------------
+# Create a container to work with.
+#[user@desktop]
+
+    source "${HOME:?}/aglais.env"
+
+    podman run \
+        --rm \
+        --tty \
+        --interactive \
+        --name ansibler \
+        --hostname ansibler \
+        --publish 3000:3000 \
+        --env "SSH_AUTH_SOCK=/mnt/ssh_auth_sock" \
+        --volume "${SSH_AUTH_SOCK}:/mnt/ssh_auth_sock:rw,z" \
+        --volume "${HOME:?}/clouds.yaml:/etc/openstack/clouds.yaml:ro,z" \
+        --volume "${AGLAIS_CODE:?}/deployments:/deployments:ro,z" \
+        ghcr.io/wfau/atolmis/ansible-client:2022.03.19 \
+        bash
+
+
+# -----------------------------------------------------
+# Set the target configuration.
+#[root@ansibler]
+
+    cloudbase='arcus'
+    cloudname='iris-gaia-red'
+    configname=zeppelin-26.43-spark-3.26.43
+
+
+# -----------------------------------------------------
+# Delete everything.
+#[root@ansibler]
+
+    time \
+        /deployments/openstack/bin/delete-all.sh \
+            "${cloudname:?}"
+
+    >  Done
+
+
+
+# -----------------------------------------------------
+# Create everything.
+#[root@ansibler]
+
+    time \
+        /deployments/hadoop-yarn/bin/create-all.sh \
+            "${cloudname:?}" \
+            "${configname:?}" \
+            "zeppelin.gaia-dmp.uk" \
+        | tee /tmp/create-all.log
+
+    >  Done
+
+
+	---- ----
+	Restarting Zeppelin
+	Zeppelin stop                                              [  OK  ]
+	Zeppelin start                                             [  OK  ]
+
+	real	42m37.960s
+	user	8m41.283s
+	sys	1m36.339s
+
+
+# -----------------------------------------------------
+# Add the ssh key for our data node.
+# This is used by the getpasshash function in the client container.
+#[root@ansibler]
+
+    ssh-keyscan 'data.aglais.uk' >> "${HOME}/.ssh/known_hosts"
+    
+
+
+# -----------------------------------------------------
+# Copy certificates from data server
+#[root@ansibler]
+
+    scp -r fedora@data.aglais.uk:/home/fedora/certs/ /root/
+    
+    
+            
+# -----------------------------------------------------
+# Get the public IP address of our Zeppelin node.
+#[root@ansibler]
+
+    cloudname=$(
+        yq eval \
+            '.aglais.spec.openstack.cloud.name' \
+            '/tmp/aglais-status.yml'
+        )
+
+    deployname=$(
+        yq eval \
+            '.aglais.status.deployment.name' \
+            '/tmp/aglais-status.yml'
+        )
+
+    zeppelinid=$(
+        openstack \
+            --os-cloud "${cloudname:?}" \
+            server list \
+                --format json \
+        | jq -r '.[] | select(.Name == "'${deployname:?}'-zeppelin") | .ID'
+        )
+
+    zeppelinip=$(
+        openstack \
+            --os-cloud "${cloudname:?}" \
+            server show \
+                --format json \
+                "${zeppelinid:?}" \
+        | jq -r ".addresses | .\"${deployname}-internal-network\" | .[1]"
+        )
+
+cat << EOF
+Zeppelin ID [${zeppelinid:?}]
+Zeppelin IP [${zeppelinip:?}]
+EOF
+
+  
+> Zeppelin ID [f19cce84-fc13-4e88-889d-3127d79dcc7d]
+> Zeppelin IP [128.232.227.158]
+
+
+# Update the dns entry with new IP
+# zeppelin.gaia-dmp.uk -> 128.232.227.158
+
+ducktoken=[TOKEN_HERE]
+duckname=aglais-live
+zeppelinip=128.232.227.158
+curl "https://www.duckdns.org/update/${duckname:?}/${ducktoken:?}/${zeppelinip:?}"
+
+# [Success]
+
+# -----------------------------------------------------
+# Enable HTTPS
+#[root@ansibler]
+
+    time \
+        /deployments/hadoop-yarn/bin/setup-ssl.sh \
+            "${cloudname:?}" \
+            "${configname:?}" \
+        | tee /tmp/setup-ssl.log
+
+        > Done
+	 ---- ----
+	Starting NGINX
+
+	real	1m2.921s
+	user	0m10.647s
+	sys	0m1.751s
+
+# -----------------------------------------------------
+# Create our shiro-auth database.
+#[root@ansibler]
+
+    time \
+        /deployments/hadoop-yarn/bin/create-auth-database.sh \
+            "${cloudname:?}" \
+            "${configname:?}" \
+        | tee /tmp/create-auth-database.log
+
+        > Done
+
+
+
+# -----------------------------------------------------
+# Copy notebooks from the live server.
+#[root@ansibler]
+
+
+     ssh zeppelin \
+        '
+        sshuser=fedora
+        sshhost=data.aglais.uk
+
+        sudo mkdir -p '/var/local/backups'
+        sudo mv "/home/fedora/zeppelin/notebook" \
+           "/var/local/backups/notebook-$(date '+%Y%m%d%H%M%S')"
+
+
+        rsync \
+            --perms \
+            --times \
+            --group \
+            --owner \
+            --stats \
+            --progress \
+            --human-readable \
+            --checksum \
+            --recursive \
+            "${sshuser:?}@${sshhost:?}://var/local/backups/notebook/" \
+            "/home/fedora/zeppelin/notebook"
+        '
+        
+        > Done
+        
+        
+# Remove test notebook:
+  ssh zeppelin 'rm "/home/fedora/zeppelin/notebook/Untitled Note 1_2H3R2UM2V.zpln"'
+
+
+# -----------------------------------------------------
+# Restart Zeppelin
+#[root@ansibler]
+
+    ssh zeppelin \
+        '
+        zeppelin-daemon.sh restart
+        '
+
+
+# -----------------------------------------------------
+# Delete users, so that we can recreate them
+    ssh zeppelin 'sudo userdel -r stv'
+    ssh zeppelin 'sudo userdel -r zrq'
+    ssh zeppelin 'sudo userdel -r nch'
+    ssh zeppelin 'sudo userdel -r dcr'
+	
+# -----------------------------------------------------
+# Create users
+
+source /deployments/zeppelin/bin/create-user-tools.sh
+
+createusermain \
+        "stv" "admin" \
+    | jq '.'
+    
+{
+  "linuxuser": {
+    "name": "stv",
+    "type": "admin",
+    "home": "/home/stv",
+    "uid": 20001
+  },
+  "shirouser": {
+    "name": "stv",
+    "type": "admin",
+    "pass": "",
+    "hash": ""
+  },
+  "hdfsspace": {
+    "path": "/albert/stv",
+    "owner": "stv",
+    "group": "supergroup"
+  },
+  "notebooks": {}
+}
+
+
+createusermain \
+        "zrq" "admin" \
+    | jq '.'
+{
+  "linuxuser": {
+    "name": "zrq",
+    "type": "admin",
+    "home": "/home/zrq",
+    "uid": 20002
+  },
+  "shirouser": {
+    "name": "zrq",
+    "type": "admin",
+    "pass": "",
+    "hash": ""
+  },
+  "hdfsspace": {
+    "path": "/albert/zrq",
+    "owner": "zrq",
+    "group": "supergroup"
+  },
+  "notebooks": {}
+}
+
+
+createusermain \
+        "nch" "admin" \
+    | jq '.'
+{
+  "linuxuser": {
+    "name": "nch",
+    "type": "admin",
+    "home": "/home/nch",
+    "uid": 20003
+  },
+  "shirouser": {
+    "name": "nch",
+    "type": "admin",
+    "pass": "",
+    "hash": ""
+  },
+  "hdfsspace": {
+    "path": "/albert/nch",
+    "owner": "nch",
+    "group": "supergroup"
+  },
+  "notebooks": {}
+}
+
+
+createusermain \
+        "dcr" "user" \
+    | jq '.' 
+    
+{
+  "linuxuser": {
+    "name": "dcr",
+    "type": "user",
+    "home": "/home/dcr",
+    "uid": 20004
+  },
+  "shirouser": {
+    "name": "dcr",
+    "type": "user",
+    "pass": "",
+    "hash": ""
+  },
+  "hdfsspace": {
+    "path": "/albert/dcr",
+    "owner": "dcr",
+    "group": "supergroup"
+  },
+  "notebooks": {}
+}
+
+
+	
+# -----------------------------------------------------	
+# Test & Validate user login & Spark job via UI
+# Success
+
+# Test simple Spark notebook (Source Count)
+# Success
+

--- a/notes/stv/20220706-certbot-for-live.txt
+++ b/notes/stv/20220706-certbot-for-live.txt
@@ -1,0 +1,175 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2021, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#  
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+#
+
+
+
+    Target:
+
+        Setup NGINX proxy for Zeppelin & Setup SSL for Zeppelin installation
+
+    Result:
+
+        SUCCESS
+
+# On an existing system which has been creating using latest scripts which enable nginx and https
+# Create new certificates for the zeppelin.gaia-dmp.uk hostname
+
+
+# Change zeppelin.gaia-dmp.uk  to use our IP address (done by dmr)
+
+
+# ---------------------------------------------
+# Update the NGINX Proxy Configuration for Zeppelin to use the new hostname
+# root@zeppelin
+rm /etc/nginx/conf.d/zeppelin.conf
+
+cat > "/etc/nginx/conf.d/zeppelin.conf" << EOF
+
+# Zeppelin Website
+
+server {
+    server_name http://zeppelin.gaia-dmp.uk/;            
+
+    location / {    # For regular websever support
+            proxy_pass http://zeppelin:8080/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+
+            client_max_body_size       10m;
+            client_body_buffer_size    128k;
+
+            proxy_connect_timeout      90;
+            proxy_send_timeout         90;
+            proxy_read_timeout         90;
+
+            proxy_buffer_size          4k;
+            proxy_buffers              4 32k;
+            proxy_busy_buffers_size    64k;
+            proxy_temp_file_write_size 64k;
+    }
+
+    location /ws {  # For websocket support
+            proxy_pass http://zeppelin:8080/ws;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade websocket;
+            proxy_set_header Connection upgrade;
+            proxy_read_timeout 86400;
+    }
+
+ 
+}
+
+EOF
+
+# ---------------------------------------------
+# Restart NGINX
+# fedora@zeppelin
+
+sudo systemctl restart nginx
+
+
+
+# ---------------------------------------------
+# Run certbot to install certificate for Nginx
+# fedora@zeppelin
+ 
+
+sudo certbot --nginx
+
+Saving debug log to /var/log/letsencrypt/letsencrypt.log
+Plugins selected: Authenticator nginx, Installer nginx
+
+Which names would you like to activate HTTPS for?
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+1: zeppelin.gaia-dmp.uk
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Select the appropriate numbers separated by commas and/or spaces, or leave input
+blank to select all options shown (Enter 'c' to cancel): 1
+Obtaining a new certificate
+Performing the following challenges:
+http-01 challenge for zeppelin.gaia-dmp.uk
+Waiting for verification...
+Cleaning up challenges
+Deploying Certificate to VirtualHost /etc/nginx/conf.d/zeppelin.conf
+Redirecting all traffic on port 80 to ssl in /etc/nginx/conf.d/zeppelin.conf
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Congratulations! You have successfully enabled https://zeppelin.gaia-dmp.uk
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+IMPORTANT NOTES:
+ - Congratulations! Your certificate and chain have been saved at:
+   /etc/letsencrypt/live/zeppelin.gaia-dmp.uk/fullchain.pem
+   Your key file has been saved at:
+   /etc/letsencrypt/live/zeppelin.gaia-dmp.uk/privkey.pem
+   Your cert will expire on 2022-10-04. To obtain a new or tweaked
+   version of this certificate in the future, simply run certbot again
+   with the "certonly" option. To non-interactively renew *all* of
+   your certificates, run "certbot renew"
+ - If you like Certbot, please consider supporting our work by:
+
+   Donating to ISRG / Let's Encrypt:   https://letsencrypt.org/donate
+   Donating to EFF:                    https://eff.org/donate-le
+
+
+
+# --------------------------------
+# Reload NGINX 
+# fedora@zeppelin
+
+sudo nginx -s reload
+
+
+# --------------------------------
+# Access Zeppelin UI 
+# user@desktop
+
+firefox https://zeppelin.gaia-dmp.uk
+
+# [SUCCESS]
+
+
+
+# -----------------------------------------
+# Renewing Let's Encrypt Certificate
+# fedora@zeppelin
+
+sudo certbot renew --post-hook "nginx -s reload"
+
+     > 
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Processing /etc/letsencrypt/renewal/zeppelin.gaia-dmp.uk.conf
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Cert not yet due for renewal
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+The following certs are not due for renewal yet:
+  /etc/letsencrypt/live/zeppelin.gaia-dmp.uk/fullchain.pem expires on 2022-10-04 (skipped)
+No renewals were attempted.
+No hooks were run.
+
+
+

--- a/notes/stv/20220706-certbot-for-live.txt
+++ b/notes/stv/20220706-certbot-for-live.txt
@@ -83,6 +83,14 @@ server {
 
 EOF
 
+
+# ---------------------------------------------
+# Install certbot and nginx plugin
+# fedora@zeppelin
+
+sudo yum install -y certbot
+sudo yum install -y certbot python3-certbot-nginx
+
 # ---------------------------------------------
 # Restart NGINX
 # fedora@zeppelin

--- a/notes/stv/20220707-01-red-deploy-https-live.txt
+++ b/notes/stv/20220707-01-red-deploy-https-live.txt
@@ -1,0 +1,374 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2022, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+
+
+
+    Target:
+
+        Test deployment with NGINX proxy and HTTPS
+
+    Result:
+
+
+
+
+# -----------------------------------------------------
+# Create a container to work with.
+#[user@desktop]
+
+    source "${HOME:?}/aglais.env"
+
+    podman run \
+        --rm \
+        --tty \
+        --interactive \
+        --name ansibler \
+        --hostname ansibler \
+        --publish 3000:3000 \
+        --env "SSH_AUTH_SOCK=/mnt/ssh_auth_sock" \
+        --volume "${SSH_AUTH_SOCK}:/mnt/ssh_auth_sock:rw,z" \
+        --volume "${HOME:?}/clouds.yaml:/etc/openstack/clouds.yaml:ro,z" \
+        --volume "${AGLAIS_CODE:?}/deployments:/deployments:ro,z" \
+        ghcr.io/wfau/atolmis/ansible-client:2022.03.19 \
+        bash
+
+
+# -----------------------------------------------------
+# Set the target configuration.
+#[root@ansibler]
+
+    cloudbase='arcus'
+    cloudname='iris-gaia-red'
+    configname=zeppelin-26.43-spark-3.26.43
+
+
+# -----------------------------------------------------
+# Delete everything.
+#[root@ansibler]
+
+    time \
+        /deployments/openstack/bin/delete-all.sh \
+            "${cloudname:?}"
+
+    >  Done
+
+
+
+# -----------------------------------------------------
+# Create everything.
+#[root@ansibler]
+
+    time \
+        /deployments/hadoop-yarn/bin/create-all.sh \
+            "${cloudname:?}" \
+            "${configname:?}" \
+            "dmp.gaia.ac.uk" \
+        | tee /tmp/create-all.log
+
+    >  Done
+
+
+	---- ----
+	Restarting Zeppelin
+	Zeppelin stop                                              [  OK  ]
+	Zeppelin start                                             [  OK  ]
+
+	real	42m37.960s
+	user	8m41.283s
+	sys	1m36.339s
+
+
+# -----------------------------------------------------
+# Add the ssh key for our data node.
+# This is used by the getpasshash function in the client container.
+#[root@ansibler]
+
+    ssh-keyscan 'data.aglais.uk' >> "${HOME}/.ssh/known_hosts"
+    
+
+
+# -----------------------------------------------------
+# Copy certificates from data server
+#[root@ansibler]
+
+    scp -r fedora@data.aglais.uk:/home/fedora/certs/ /root/
+    
+    
+            
+# -----------------------------------------------------
+# Get the public IP address of our Zeppelin node.
+#[root@ansibler]
+
+    cloudname=$(
+        yq eval \
+            '.aglais.spec.openstack.cloud.name' \
+            '/tmp/aglais-status.yml'
+        )
+
+    deployname=$(
+        yq eval \
+            '.aglais.status.deployment.name' \
+            '/tmp/aglais-status.yml'
+        )
+
+    zeppelinid=$(
+        openstack \
+            --os-cloud "${cloudname:?}" \
+            server list \
+                --format json \
+        | jq -r '.[] | select(.Name == "'${deployname:?}'-zeppelin") | .ID'
+        )
+
+    zeppelinip=$(
+        openstack \
+            --os-cloud "${cloudname:?}" \
+            server show \
+                --format json \
+                "${zeppelinid:?}" \
+        | jq -r ".addresses | .\"${deployname}-internal-network\" | .[1]"
+        )
+
+cat << EOF
+Zeppelin ID [${zeppelinid:?}]
+Zeppelin IP [${zeppelinip:?}]
+EOF
+
+> Zeppelin ID [428d73b1-c4c5-4213-bfcd-5db7780786e1]
+> Zeppelin IP [128.232.227.219]
+
+
+
+
+# Update the dns entry with new IP
+# zeppelin.gaia-dmp.uk -> 128.232.227.219
+
+ducktoken=..
+duckname=aglais-live
+zeppelinip=128.232.227.219
+curl "https://www.duckdns.org/update/${duckname:?}/${ducktoken:?}/${zeppelinip:?}"
+
+# [Success]
+
+# -----------------------------------------------------
+# Enable HTTPS
+#[root@ansibler]
+
+    time \
+        /deployments/hadoop-yarn/bin/setup-ssl.sh \
+            "${cloudname:?}" \
+            "${configname:?}" \
+        | tee /tmp/setup-ssl.log
+
+        > Done
+
+
+# -----------------------------------------------------
+# Create our shiro-auth database.
+#[root@ansibler]
+
+    time \
+        /deployments/hadoop-yarn/bin/create-auth-database.sh \
+            "${cloudname:?}" \
+            "${configname:?}" \
+        | tee /tmp/create-auth-database.log
+
+        > Done
+
+
+
+# -----------------------------------------------------
+# Copy notebooks from the live server.
+#[root@ansibler]
+
+
+     ssh zeppelin \
+        '
+        sshuser=fedora
+        sshhost=data.aglais.uk
+
+        sudo mkdir -p '/var/local/backups'
+        sudo mv "/home/fedora/zeppelin/notebook" \
+           "/var/local/backups/notebook-$(date '+%Y%m%d%H%M%S')"
+
+
+        rsync \
+            --perms \
+            --times \
+            --group \
+            --owner \
+            --stats \
+            --progress \
+            --human-readable \
+            --checksum \
+            --recursive \
+            "${sshuser:?}@${sshhost:?}://var/local/backups/notebook/" \
+            "/home/fedora/zeppelin/notebook"
+        '
+        
+        > Done
+        
+        
+# Remove test notebook:
+  ssh zeppelin 'rm "/home/fedora/zeppelin/notebook/Untitled Note 1_2H3R2UM2V.zpln"'
+
+
+# -----------------------------------------------------
+# Restart Zeppelin
+#[root@ansibler]
+
+    ssh zeppelin \
+        '
+        zeppelin-daemon.sh restart
+        '
+
+
+# -----------------------------------------------------
+# Delete users, so that we can recreate them
+    ssh zeppelin 'sudo userdel -r stv'
+    ssh zeppelin 'sudo userdel -r zrq'
+    ssh zeppelin 'sudo userdel -r nch'
+    ssh zeppelin 'sudo userdel -r dcr'
+	
+# -----------------------------------------------------
+# Create users
+
+source /deployments/zeppelin/bin/create-user-tools.sh
+
+createusermain \
+        "stv" "admin" \
+    | jq '.'
+    
+{
+  "linuxuser": {
+    "name": "stv",
+    "type": "admin",
+    "home": "/home/stv",
+    "uid": 20001
+  },
+  "shirouser": {
+    "name": "stv",
+    "type": "admin",
+    "pass": "",
+    "hash": ""
+  },
+  "hdfsspace": {
+    "path": "/albert/stv",
+    "owner": "stv",
+    "group": "supergroup"
+  },
+  "notebooks": {}
+}
+
+
+createusermain \
+        "zrq" "admin" \
+    | jq '.'
+{
+  "linuxuser": {
+    "name": "zrq",
+    "type": "admin",
+    "home": "/home/zrq",
+    "uid": 20002
+  },
+  "shirouser": {
+    "name": "zrq",
+    "type": "admin",
+    "pass": "",
+    "hash": ""
+  },
+  "hdfsspace": {
+    "path": "/albert/zrq",
+    "owner": "zrq",
+    "group": "supergroup"
+  },
+  "notebooks": {}
+}
+
+
+createusermain \
+        "nch" "admin" \
+    | jq '.'
+{
+  "linuxuser": {
+    "name": "nch",
+    "type": "admin",
+    "home": "/home/nch",
+    "uid": 20003
+  },
+  "shirouser": {
+    "name": "nch",
+    "type": "admin",
+    "pass": "",
+    "hash": ""
+  },
+  "hdfsspace": {
+    "path": "/albert/nch",
+    "owner": "nch",
+    "group": "supergroup"
+  },
+  "notebooks": {}
+}
+
+
+createusermain \
+        "dcr" "user" \
+    | jq '.' 
+    
+{
+  "linuxuser": {
+    "name": "dcr",
+    "type": "user",
+    "home": "/home/dcr",
+    "uid": 20004
+  },
+  "shirouser": {
+    "name": "dcr",
+    "type": "user",
+    "pass": "",
+    "hash": ""
+  },
+  "hdfsspace": {
+    "path": "/albert/dcr",
+    "owner": "dcr",
+    "group": "supergroup"
+  },
+  "notebooks": {}
+}
+
+
+# Test out Spark notebooks on:
+https://dmp.gaia.ac.uk/#/?ref=%2F
+	
+# -----------------------------------------------------	
+# Test & Validate user login & Spark job via UI
+# Success
+
+# Test simple Spark notebook (Source Count)
+# Success
+
+
+# -----------------------------------------
+# Renewing Let's Encrypt Certificate
+# fedora@zeppelin
+
+sudo certbot renew --post-hook "nginx -s reload"
+
+> Success

--- a/notes/stv/20220707-setup-certificates-live-01.txt
+++ b/notes/stv/20220707-setup-certificates-live-01.txt
@@ -1,0 +1,179 @@
+#
+# <meta:header>
+#   <meta:licence>
+#     Copyright (c) 2021, ROE (http://www.roe.ac.uk/)
+#
+#     This information is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     This information is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#  
+#     You should have received a copy of the GNU General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#   </meta:licence>
+# </meta:header>
+#
+#
+
+
+
+    Target:
+
+        Setup NGINX proxy for Zeppelin & Setup SSL for Zeppelin installation
+        Note this was running on an existing deploy (blue.aglais.uk)
+    Result:
+
+        SUCCESS
+
+
+# ---------------------------------------------
+# Update Yum
+# fedora@zeppelin
+
+sudo yum update
+
+
+# ---------------------------------------------
+# Install NGINX
+# fedora@zeppelin
+
+sudo yum install -y nginx
+
+# Needed to avoid permission errors
+
+setsebool -P httpd_can_network_connect 1
+
+
+# ---------------------------------------------
+# Setup NGINX Proxy Configuration for Zeppelin
+# fedora@zeppelin
+
+cat > "/etc/nginx/conf.d/zeppelin.conf" << EOF
+
+# Zeppelin Website
+
+server {
+    server_name dmp.gaia.ac.uk;            
+
+    location / {    # For regular websever support
+            proxy_pass http://zeppelin:8080/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+
+            client_max_body_size       10m;
+            client_body_buffer_size    128k;
+
+            proxy_connect_timeout      90;
+            proxy_send_timeout         90;
+            proxy_read_timeout         90;
+
+            proxy_buffer_size          4k;
+            proxy_buffers              4 32k;
+            proxy_busy_buffers_size    64k;
+            proxy_temp_file_write_size 64k;
+    }
+
+    location /ws {  # For websocket support
+            proxy_pass http://zeppelin:8080/ws;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade websocket;
+            proxy_set_header Connection upgrade;
+            proxy_read_timeout 86400;
+    }
+
+
+}
+
+EOF
+
+
+# Fix proxy set header which didn't end up properly in config file
+
+
+EOF
+
+# ---------------------------------------------
+# Restart NGINX
+# fedora@zeppelin
+
+sudo systemctl restart nginx.service
+
+
+
+# ---------------------------------------------
+# Install certbot and nginx plugin
+# fedora@zeppelin
+
+sudo yum install -y certbot
+sudo yum install -y certbot python3-certbot-nginx
+
+
+
+# Update the dns entry with new IP
+# dmp.gaia.ac.uk -> 128.232.227.196
+
+ducktoken=ENTER-TOKEN-HERE
+duckname=aglais-live
+zeppelinip=128.232.227.196
+curl "https://www.duckdns.org/update/${duckname:?}/${ducktoken:?}/${zeppelinip:?}"
+
+
+
+# ---------------------------------------------
+# Run certbot to install certificate for Nginx
+# fedora@zeppelin
+
+
+sudo certbot --nginx
+
+..
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Congratulations! You have successfully enabled https://dmp.gaia.ac.uk
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+
+
+# Check https://dmp.gaia.ac.uk
+# Success!
+
+# Targzip letsencrypt directory onto data.aglais.uk
+
+# fedora@zeppelin
+pushd /etc/
+  tar zcvf /tmp/certs.tar.gz letsencrypt
+popd
+
+# Deploy ansibler container (temp fix, need to fix ssh config to access from local)
+
+
+    source "${HOME:?}/aglais.env"
+
+    podman run \
+        --rm \
+        --tty \
+        --interactive \
+        --name ansibler \
+        --hostname ansibler \
+        --publish 3000:3000 \
+        --env "SSH_AUTH_SOCK=/mnt/ssh_auth_sock" \
+        --volume "${SSH_AUTH_SOCK}:/mnt/ssh_auth_sock:rw,z" \
+        --volume "${HOME:?}/clouds.yaml:/etc/openstack/clouds.yaml:ro,z" \
+        --volume "${AGLAIS_CODE:?}/deployments:/deployments:ro,z" \
+        ghcr.io/wfau/atolmis/ansible-client:2022.03.19 \
+        bash
+
+
+# root@ansibler  
+
+  scp fedora@blue.aglais.uk:/tmp/certs.tar.gz /home/
+  scp /home/certs.tar.gz fedora@data.aglais.uk:/home/fedora/certs/
+


### PR DESCRIPTION
Includes notes on how certificate was created, and how it was tested
Create-all has been modified and now accepts a hostname to use as the nginx server-name
